### PR TITLE
docs: v3 crypto parity, technical-manual restyle, hivemind-core naming, light-blue theme

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,56 +1,70 @@
 # What is HiveMind?
 
-HiveMind is an open-source protocol and platform that connects lightweight **satellite** devices to a central AI **hub** over the network — including hardware that cannot run a full AI system on its own.
+**HiveMind is an open-source protocol and platform** that connects lightweight **satellite** devices to a central AI server — **hivemind-core** — over the network, including hardware that cannot run a full AI system on its own.
+
+!!! abstract "In a nutshell"
+    - Satellites delegate reasoning, skills, and audio processing to hivemind-core, which serves many of them with independent sessions and permissions.
+    - Configure hivemind-core with an OVOS skills backend for home automation and skills, or a persona backend to just chat with an LLM.
+    - Satellites range from text-only CLI clients to full local voice stacks; hivemind-core instances can chain into a mesh.
+    - HiveMind is a gateway around OVOS, not a replacement for it, and runs entirely on your own hardware.
 
 ## The core idea
 
-HiveMind separates AI workload from edge devices. Satellites (microphones, voice devices, browsers, chat clients) delegate processing to a hub, which handles reasoning, skills, and audio processing. The hub can serve many satellites simultaneously with independent sessions and permissions for each.
+HiveMind separates AI workload from edge devices. Satellites (microphones, voice devices, browsers, chat clients) delegate processing to hivemind-core, which handles reasoning, skills, and audio processing. hivemind-core can serve many satellites simultaneously with independent sessions and permissions for each.
 
 New here? The [Glossary](reference/glossary.md) defines every term on this page.
 
 ```
 [Mic Satellite]  ──┐
-[Voice Relay]    ───┤──→ [HiveMind Hub] ──→ skills / LLM / intents
+[Voice Relay]    ───┤──→ [hivemind-core] ──→ skills / LLM / intents
 [Voice Satellite]──┤         │
 [CLI Client]     ───┘        └──→ responses back to each satellite
 ```
 
-## Hub types
+---
 
-Pick the **[OVOS](reference/glossary.md#ovos-voice-vocabulary) skills hub** if you want skills/home-automation; pick the **[Persona](reference/glossary.md#ovos-voice-vocabulary) hub** if you just want to chat with an LLM and want the simplest setup (no OVOS required).
+## Backend types
 
-| Hub | Package | Agent backend |
+Pick the **[OVOS](reference/glossary.md#ovos-voice-vocabulary) skills backend** if you want skills/home-automation; pick the **[Persona](reference/glossary.md#ovos-voice-vocabulary) backend** if you just want to chat with an LLM and want the simplest setup (no OVOS required).
+
+| Backend | Package | Agent backend |
 |---|---|---|
 | OVOS skills server | `hivemind-core` | OpenVoiceOS (full skill ecosystem) |
-| Audio hub | `hivemind-core` + `hivemind-audio-binary-protocol` | OVOS + server-side [STT](reference/glossary.md#ovos-voice-vocabulary)/[TTS](reference/glossary.md#ovos-voice-vocabulary)/wakeword |
+| Audio server | `hivemind-core` + `hivemind-audio-binary-protocol` | OVOS + server-side [STT](reference/glossary.md#ovos-voice-vocabulary)/[TTS](reference/glossary.md#ovos-voice-vocabulary)/wakeword |
 | Persona server | `hivemind-core` + `hivemind-persona-agent-plugin` | LLMs and chatbots via `ovos-persona` |
+
+---
 
 ## Satellite types
 
 Satellites form a spectrum based on where audio processing happens. At one end the satellite does nothing but pass text; at the other it handles the complete voice stack locally.
 
-| Satellite | Local processing | Hub requirements |
+| Satellite | Local processing | Server requirements |
 |---|---|---|
-| **HiveMind-cli** | Text I/O only | Any hub |
+| **HiveMind-cli** | Text I/O only | Any hivemind-core |
 | **hivemind-mic-satellite** | Mic + [VAD](reference/glossary.md#ovos-voice-vocabulary) | Audio binary protocol for STT/TTS/wakeword |
 | **HiveMind-voice-relay** | Mic + VAD + Wakeword | Audio binary protocol for STT/TTS |
-| **HiveMind-voice-sat** | Mic + VAD + Wakeword + STT + TTS | Any hub (sends text utterances) |
-| **hivemind-webspeech** | Browser mic + VAD | Hub listener + `allow-msg` (see page) |
+| **HiveMind-voice-sat** | Mic + VAD + Wakeword + STT + TTS | Any hivemind-core (sends text utterances) |
+| **hivemind-webspeech** | Browser mic + VAD | hivemind-core listener + `allow-msg` (see page) |
 | **ESP32 / MicroPython** | Mic (and, on some boards, VAD/wakeword) | Audio binary protocol |
 
 See [Choosing a Satellite](satellites/index.md) for a detailed comparison.
 
+---
+
 ## Mesh topology
 
-HiveMind hubs can connect to other hubs, forming a hierarchy. A sub-hub acts as a client to its parent while being a server to its own satellites. `ESCALATE` messages travel up the chain; `BROADCAST` messages travel down. This enables multi-room or multi-household topologies where each hub controls its local devices but can route requests upward.
+HiveMind-core instances can connect to other instances, forming a hierarchy. A child instance acts as a client to its parent while being a server to its own satellites. `ESCALATE` messages travel up the chain; `BROADCAST` messages travel down. This enables multi-room or multi-household topologies where each instance controls its local devices but can route requests upward.
 
 ```
-[Master Hub]
-    ├──→ [Sub-hub A] ──→ satellites
-    └──→ [Sub-hub B] ──→ satellites
+[Root hivemind-core]
+    ├──→ [Child A] ──→ satellites
+    └──→ [Child B] ──→ satellites
 ```
 
 See [Nested Hives](concepts/mesh.md#nested-hives) for details.
+
+---
 
 ## Security model
 
@@ -60,6 +74,8 @@ Permissions are configured per client. The default policy admits only a basic se
 
 See [Security](concepts/security.md) for the full model.
 
+---
+
 ## What HiveMind is not
 
 - It is **not** a replacement for OVOS when running as a skills server. OVOS remains the AI back-end; HiveMind is the external-facing gateway.
@@ -68,4 +84,4 @@ See [Security](concepts/security.md) for the full model.
 
 ---
 
-**Next:** [Quick Start](quickstart.md) to set up your first hub and satellite, or [Core Concepts](concepts/protocol.md) for how the protocol works.
+**Next:** [Quick Start](quickstart.md) to set up your first hivemind-core and satellite, or [Core Concepts](concepts/protocol.md) for how the protocol works.

--- a/docs/concepts/databases.md
+++ b/docs/concepts/databases.md
@@ -1,14 +1,19 @@
 # Database Backends
 
-In plain terms: the hub needs somewhere to remember which devices are allowed to connect and what each one is permitted to do. That store is swappable — a single file for simple setups, or a shared Redis server when you run several hubs.
+**hivemind-core stores which devices may connect and what each is permitted to do in a swappable database backend.** `hivemind-core` keeps client credentials and settings there — a single file for simple setups, or a shared Redis server when you run several hivemind-core instances.
 
-`hivemind-core` stores client credentials and settings in a pluggable database backend.
+!!! abstract "In a nutshell"
+    - Three backends: SQLite (default for new installs), JSON (human-readable, unsafe under concurrent writes), and Redis (for multi-instance deployments).
+    - The backend is chosen in the `database` block of `~/.config/hivemind-core/server.json`, never as a CLI flag; `listen` and every client command read the same config.
+    - Migrate between backends with `migrate-db`; both file backends support encryption at rest via a `password` key.
 
 | Backend | Module (package) | Default location | Best for |
 |---|---|---|---|
 | **SQLite** | `hivemind-sqlite-db-plugin` (`hivemind-sqlite-database`) | XDG data dir, e.g. `~/.local/share/hivemind-core/clients.db` | New installations (default) |
 | **JSON** | `hivemind-json-db-plugin` | XDG data dir, e.g. `~/.local/share/hivemind-core/clients.json` | Existing installs; manual inspection |
 | **Redis** | `hivemind-redis-db-plugin` (`hivemind-redis-database`) | `127.0.0.1:6379` | Distributed or multi-instance deployments |
+
+---
 
 ## Choosing a backend
 
@@ -26,6 +31,8 @@ In plain terms: the hub needs somewhere to remember which devices are allowed to
 
     Relatedly, `migrate-db` defaults to `--from json --to sqlite`, matching the most common upgrade path.
 
+---
+
 ## Migrating between backends
 
 `migrate-db` takes the full plugin module names for source and target. `--from` defaults to the JSON backend; `--to` defaults to SQLite. There is no auto-detection.
@@ -37,6 +44,8 @@ hivemind-core migrate-db \
 ```
 
 Records are copied with their full credentials and metadata; the source database is left untouched.
+
+---
 
 ## Selecting a backend
 
@@ -58,6 +67,8 @@ Backend selection is **not** a command-line flag — `hivemind-core listen` take
 ```
 
 Set `module` to the desired plugin (`hivemind-sqlite-db-plugin`, `hivemind-json-db-plugin`, or `hivemind-redis-db-plugin`) and provide a same-named sub-block with that backend's connection settings. The same configuration is read by `listen` and by every client-management command (`add-client`, `allow-msg`, …), so they always operate on the same database.
+
+---
 
 ## Security notes
 
@@ -86,6 +97,8 @@ General:
 - Audit database access logs periodically
 - Store backup files encrypted
 - Monitor for unexpected access patterns
+
+---
 
 ## Source
 

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -1,10 +1,17 @@
 # Auto Discovery
 
-In plain terms: instead of typing the hub's network address into every device by hand, discovery lets satellites find the hub on their own — either by listening for it on the local network, or (for first-time setup with no keyboard) by exchanging credentials through sound.
+**Discovery lets satellites find hivemind-core on their own** instead of having its network address typed into every device by hand — either by listening for it on the local network, or (for first-time setup with no keyboard) by exchanging credentials through sound.
 
-> **Auto-discovery is optional.** `hivemind-core` works fine with a manually configured `--host` (or a `default_master` in the identity file) — satellites connect straight to a known address with no discovery layer. Install [HiveMind-presence](https://github.com/JarbasHiveMind/HiveMind-presence) only if you want satellites to find the hub automatically.
+!!! abstract "In a nutshell"
+    - Discovery is optional and provided by the separate [HiveMind-presence](https://github.com/JarbasHiveMind/HiveMind-presence) package; `hivemind-core` runs fine with a manually configured host.
+    - mDNS/Zeroconf is the default network transport; UPnP/SSDP is supported but off by default.
+    - GGWave audio pairing exchanges credentials through sound for keyboard-free first-time setup.
+
+> **Auto-discovery is optional.** `hivemind-core` works fine with a manually configured `--host` (or a `default_master` in the identity file) — satellites connect straight to a known address with no discovery layer. Install [HiveMind-presence](https://github.com/JarbasHiveMind/HiveMind-presence) only if you want satellites to find hivemind-core automatically.
 
 [HiveMind-presence](https://github.com/JarbasHiveMind/HiveMind-presence) enables automatic discovery of HiveMind nodes on the local network without manual address configuration. It is an optional extra package — `hivemind-core` runs without it.
+
+---
 
 ## Discovery transports
 
@@ -12,18 +19,22 @@ In plain terms: instead of typing the hub's network address into every device by
 
 **UPnP / SSDP (legacy, off by default)**: An SSDP server advertises a UPnP device descriptor; satellites scan for it. Supported but disabled by default (`--upnp` defaults to `False`). Useful where mDNS is unavailable.
 
-**HiveBeacon (planned)**: A zero-dependency UDP-broadcast transport is on the roadmap and is intended to become the default once it ships, with mDNS kept as an optional transport. It is **not yet implemented** — until it lands, mDNS/Zeroconf and UPnP/SSDP are the available transports.
+**HiveBeacon (planned)**: A zero-dependency UDP-broadcast transport, intended to become the default with mDNS kept as an optional transport. It is **not implemented** — mDNS/Zeroconf and UPnP/SSDP are the available transports.
+
+---
 
 ## Integration with hivemind-core
 
-When `hivemind-presence` is installed, start the announcer alongside the hub. The `hivemind-presence announce` command is independent of `hivemind-core listen` — run them together, or configure `hivemind-presence` as a separate service on the same machine. No changes to `~/.config/hivemind-core/server.json` are required.
+When `hivemind-presence` is installed, start the announcer alongside hivemind-core. The `hivemind-presence announce` command is independent of `hivemind-core listen` — run them together, or configure `hivemind-presence` as a separate service on the same machine. No changes to `~/.config/hivemind-core/server.json` are required.
 
-## Running the hub announcer
+---
 
-On the hub machine, start advertising:
+## Running the announcer
+
+On the hivemind-core machine, start advertising:
 
 ```bash
-hivemind-presence announce --port 5678 --name "living-room-hub"
+hivemind-presence announce --port 5678 --name "living-room-server"
 ```
 
 Options:
@@ -38,7 +49,9 @@ Options:
   --ssl BOOLEAN        Report SSL support (default: False)
 ```
 
-## Scanning for hubs
+---
+
+## Scanning for hivemind-core instances
 
 On a satellite (or any device on the same network):
 
@@ -67,14 +80,16 @@ Options:
   --service-type TEXT  HiveMind service type (default: HiveMind-websocket)
 ```
 
+---
+
 ## Audio pairing (GGWave)
 
 > **Note**: This feature is a proof-of-concept and is a work in progress.
 
-GGWave encodes data as audio tones, allowing a hub and satellite to exchange pairing credentials when they are in audible range of each other — useful for initial setup without a keyboard.
+GGWave encodes data as audio tones, allowing hivemind-core and a satellite to exchange pairing credentials when they are in audible range of each other — useful for initial setup without a keyboard.
 
 **Prerequisites:**
-- Hub device with microphone and speaker
+- hivemind-core device with microphone and speaker
 - Satellite device with microphone and speaker
 - Any GGWave transmitter to initiate the exchange — the [browser GGWave tool](https://jarbashivemind.github.io/hivemind-ggwave/) **or** the native `ggwave-cli` / `ggwave-rx` binaries
 - All devices within audible range of each other
@@ -83,21 +98,25 @@ GGWave encodes data as audio tones, allowing a hub and satellite to exchange pai
 
 1. A password is broadcast as audio (`HMPSWD`), e.g. via the [browser GGWave tool](https://jarbashivemind.github.io/hivemind-ggwave/)
 2. The satellite decodes the password, generates an access key, and sends it back as audio (`HMKEY`)
-3. The hub receives the key, adds the client, and sends an acknowledgement containing the host address as audio (`HMHOST`)
+3. hivemind-core receives the key, adds the client, and sends an acknowledgement containing the host address as audio (`HMHOST`)
 4. The satellite decodes the acknowledgement and connects
 
 After a successful GGWave pairing the satellite has a populated identity file and can connect as normal.
+
+---
 
 ## See also: hivemind-rendezvous (proof-of-concept)
 
 !!! note "Optional / proof-of-concept"
     [hivemind-rendezvous](https://github.com/JarbasHiveMind/hivemind-rendezvous) is a separate, experimental package — not part of normal discovery and not required to run a hive.
 
-Discovery above assumes nodes are online at the same time. **hivemind-rendezvous** solves the opposite case: an asynchronous **store-and-forward dead-drop** that lets two hives which are *never* online simultaneously still exchange [`INTERCOM`](protocol.md#intercom-end-to-end-encrypted-peer-to-peer) messages. A sender deposits an encrypted message keyed by the **recipient's RSA public key**; the recipient retrieves it later by proving ownership of that key with a **signed timestamp** (no server-side challenge state). It is a proof-of-concept — useful to understand the model, but not something to design a production deployment around yet.
+Discovery above assumes nodes are online at the same time. **hivemind-rendezvous** solves the opposite case: an asynchronous **store-and-forward dead-drop** that lets two hives which are *never* online simultaneously still exchange [`INTERCOM`](protocol.md#intercom-end-to-end-encrypted-peer-to-peer) messages. A sender deposits an encrypted message keyed by the **recipient's RSA public key**; the recipient retrieves it later by proving ownership of that key with a **signed timestamp** (no server-side challenge state). It is a proof-of-concept — useful to understand the model, but not something to design a production deployment around.
 
 ---
 
 **Next:** [Security](security.md) for the handshake, credentials, and admission control, or [Mesh Topology](mesh.md) for how discovered nodes route messages.
+
+---
 
 ## Source
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,12 +1,12 @@
 # Core Concepts
 
-This section explains **how HiveMind works** — the ideas behind the mesh, not the
+**This section explains how HiveMind works** — the ideas behind the mesh, not the
 commands to run it. You don't need to read it all before setting things up
 ([Quick Start](../quickstart.md) gets you running in ten minutes), but a skim here
 makes every other page click into place.
 
 !!! tip "New here? Read these two first"
-    Start with **[Mesh & Hub Topology](mesh.md)** (what the pieces are) and
+    Start with **[Mesh Topology](mesh.md)** (what the pieces are) and
     **[Security & Permissions](security.md)** (how devices trust each other). The rest
     you can read on demand.
 
@@ -14,23 +14,25 @@ makes every other page click into place.
 
 | Page | What it answers | For |
 |---|---|---|
-| [Mesh & Hub Topology](mesh.md) | What are hubs, satellites, and relays? How do messages travel up and down the mesh? | Everyone |
+| [Mesh Topology](mesh.md) | What are hivemind-core instances, satellites, and relays? How do messages travel up and down the mesh? | Everyone |
 | [Protocol & Message Types](protocol.md) | What does HiveMind actually send over the wire, and in which direction? | Curious users · developers |
-| [Security & Permissions](security.md) | How are connections encrypted, and how do you control what each device may do? | Everyone running a hub |
+| [Security & Permissions](security.md) | How are connections encrypted, and how do you control what each device may do? | Everyone running hivemind-core |
 | [Database Backends](databases.md) | Where are client credentials stored? SQLite, JSON, or Redis? | Operators |
-| [Auto Discovery](discovery.md) | How do satellites find the hub automatically on a local network? | Everyone |
+| [Auto Discovery](discovery.md) | How do satellites find hivemind-core automatically on a local network? | Everyone |
 | [Plugin Architecture](plugins.md) | The five plugin families that make every layer swappable. | Developers · advanced operators |
+
+---
 
 ## The one-paragraph version
 
-A **hub** is the brain: it runs skills, an LLM, or another AI backend. **Satellites**
+**hivemind-core** is the brain: it runs skills, an LLM, or another AI backend. **Satellites**
 are the lightweight devices you talk to — a microphone, a browser tab, a terminal.
-They connect to the hub over an **encrypted, permissioned protocol** that is agnostic
+They connect to hivemind-core over an **encrypted, permissioned protocol** that is agnostic
 to both the transport (WebSocket, HTTP, MQTT…) and the payload (OVOS messages by
-default). Hubs can connect to other hubs, forming a **mesh**: requests a hub can't
+default). hivemind-core instances can connect to other instances, forming a **mesh**: requests one instance can't
 answer **escalate** upward, and announcements **broadcast** downward. Every other page
 in this manual is a detail of that sentence.
 
 ---
 
-**Next:** [Mesh & Hub Topology](mesh.md)
+**Next:** [Mesh Topology](mesh.md)

--- a/docs/concepts/mesh.md
+++ b/docs/concepts/mesh.md
@@ -1,37 +1,46 @@
 # Mesh Topology
 
-In plain terms: a HiveMind doesn't have to be one server with some devices around it. Hubs can connect to other hubs, forming a tree of rooms, households, or sites — and messages know how to travel up, down, or across that tree to reach the right place.
+**A HiveMind can be more than one server with devices around it.** hivemind-core instances connect to other instances, forming a tree of rooms, households, or sites, and messages travel up, down, or across that tree to reach the right place.
 
-## Hubs and satellites
+!!! abstract "In a nutshell"
+    - A hivemind-core instance runs the AI back-end and accepts satellite connections; a child instance is a client to its parent and a server to its own satellites.
+    - `ESCALATE` and `QUERY` travel up the tree, `BROADCAST` travels down, and `PROPAGATE`/`CASCADE` flood in all directions.
+    - Every hop re-checks its own permission ACL, so a child instance never inherits more access than the root granted it.
 
-Every HiveMind deployment has at least one **hub** (also called a master) and one or more **satellites** (also called clients or slaves). The hub runs the AI back-end — either an OVOS skills server or a persona/LLM server — and accepts incoming connections from satellites. A satellite connects to the hub, sends utterances or messages, and receives responses.
+## hivemind-core and satellites
+
+Every HiveMind deployment has at least one **hivemind-core instance** (also called a master) and one or more **satellites** (also called clients or slaves). hivemind-core runs the AI back-end — either an OVOS skills server or a persona/LLM server — and accepts incoming connections from satellites. A satellite connects to hivemind-core, sends utterances or messages, and receives responses.
 
 ```
 [Satellite A] ──┐
-[Satellite B] ───┤──→ [Hub] ──→ OVOS / LLM
+[Satellite B] ───┤──→ [hivemind-core] ──→ OVOS / LLM
 [Satellite C] ───┘
 ```
 
 The protocol itself is transport-agnostic: WebSocket is the default, but HTTP, MQTT, and other transports are supported via network protocol plugins.
 
+---
+
 ## site_id
 
-Every satellite carries a `site_id` — a free-form string identifying its physical location (e.g. `"living-room"`, `"kitchen"`). The hub injects `site_id` into OVOS message context, allowing skills to return location-aware responses. It also lets you target `BROADCAST` messages at a specific room.
+Every satellite carries a `site_id` — a free-form string identifying its physical location (e.g. `"living-room"`, `"kitchen"`). hivemind-core injects `site_id` into OVOS message context, allowing skills to return location-aware responses. It also lets you target `BROADCAST` messages at a specific room.
+
+---
 
 ## Nested hives
 
-HiveMind hubs can connect to other hubs. A sub-hub acts as a client to its parent (sending `ESCALATE` up the chain) while acting as a server to its own satellites (sending `BROADCAST` down the chain). This creates a hierarchy:
+hivemind-core instances can connect to other instances. A child instance acts as a client to its parent (sending `ESCALATE` up the chain) while acting as a server to its own satellites (sending `BROADCAST` down the chain). This creates a hierarchy:
 
 ```
-[Root Hub]
-    ├──→ [Sub-hub A]  ──→ [Satellite A1]
-    │                 └──→ [Satellite A2]
-    └──→ [Sub-hub B]  ──→ [Satellite B1]
+[Root hivemind-core]
+    ├──→ [Child A]  ──→ [Satellite A1]
+    │               └──→ [Satellite A2]
+    └──→ [Child B]  ──→ [Satellite B1]
 ```
 
 ### ESCALATE — upward routing
 
-`ESCALATE` travels from a satellite up through sub-hubs toward the root. Use it when a node cannot handle a request locally and wants the parent to try.
+`ESCALATE` travels from a satellite up through intermediate hivemind-core instances toward the root. Use it when a node cannot handle a request locally and wants the parent to try.
 
 ### BROADCAST — downward routing
 
@@ -49,11 +58,13 @@ HiveMind hubs can connect to other hubs. A sub-hub acts as a client to its paren
 
 `CASCADE` floods in all directions like `PROPAGATE`, and every node that can answer sends a response back. The originator collects responses via `CascadeAggregator` and applies a select callback to pick the best answer. See [Protocol — CASCADE](protocol.md).
 
-> **Note:** `RENDEZVOUS` (rendezvous / wormhole relay) is a **reserved** message type. It is defined in the protocol but not yet wired into core — there is no routing handler for it, and it currently falls through to the unknown-message stub. Don't design around it.
+> **Note:** `RENDEZVOUS` (rendezvous / wormhole relay) is a **reserved** message type. It is defined in the protocol but not wired into core: there is no routing handler for it, so it falls through to the unknown-message stub. Don't design around it.
+
+---
 
 ## Relay nodes
 
-A **relay node** is a hub that is simultaneously connected upstream to a parent master. It serves its own downstream satellites while forwarding traffic in both directions.
+A **relay node** is a hivemind-core instance that is simultaneously connected upstream to a parent master. It serves its own downstream satellites while forwarding traffic in both directions.
 
 A relay is created by calling `HiveMindListenerProtocol.bind_upstream(slave_protocol)` after the slave is bound to a bus. Once bound:
 
@@ -64,46 +75,54 @@ A relay is created by calling `HiveMindListenerProtocol.bind_upstream(slave_prot
 This bidirectional relay is transparent to both the satellites below and the master above. The chain can be arbitrarily deep:
 
 ```
-[Root Hub]
-    └──→ [Relay Hub]  ──→ [Satellite A]
-                      └──→ [Satellite B]
+[Root hivemind-core]
+    └──→ [Relay node]  ──→ [Satellite A]
+                       └──→ [Satellite B]
 ```
 
-A QUERY sent by Satellite A travels up through the Relay Hub. If the Relay Hub's local agent answers, the response returns directly. If not, the QUERY continues to the Root Hub. The response retraces the path back to Satellite A.
+A QUERY sent by Satellite A travels up through the relay node. If the relay node's local agent answers, the response returns directly. If not, the QUERY continues to the root. The response retraces the path back to Satellite A.
 
-A CASCADE sent by Satellite A is forwarded to both Satellite B and up to the Root Hub (and its satellites). Responses flow back from all of them.
+A CASCADE sent by Satellite A is forwarded to both Satellite B and up to the root (and its satellites). Responses flow back from all of them.
+
+---
 
 ## Permissions across nested hives
 
-Each hop enforces its own permission chain. A sub-hub can grant clients no more access than the root has granted the sub-hub. This creates a natural permission boundary: a guest sub-hub never inherits root capabilities simply by connecting.
+Each hop enforces its own permission chain. A child instance can grant clients no more access than the root has granted the child instance. This creates a natural permission boundary: a guest instance never inherits root capabilities simply by connecting.
 
 ??? note "Advanced: why the boundary actually holds"
-    The boundary is not just a convention — it is enforced at **every hop**. A message arriving at a hub is checked against *that hub's* `allowed_types` ACL by `MessageTypeACLPolicy` (`HiveMind-core/hivemind_core/policy.py`) before it is forwarded onward. So when a sub-hub forwards a satellite's message upstream, it is itself a client of the root and is re-checked against the permissions the root granted *it*. A capability the root never granted the sub-hub can never be smuggled through by a downstream device.
+    The boundary is not just a convention — it is enforced at **every hop**. A message arriving at a hivemind-core instance is checked against *that instance's* `allowed_types` ACL by `MessageTypeACLPolicy` (`HiveMind-core/hivemind_core/policy.py`) before it is forwarded onward. So when a child instance forwards a satellite's message upstream, it is itself a client of the root and is re-checked against the permissions the root granted *it*. A capability the root never granted the child instance can never be smuggled through by a downstream device.
 
     For concrete multi-hop routing tables and worked topology examples, see the [hivemind-test-harness docs](https://github.com/JarbasHiveMind/hivemind-test-harness/blob/HEAD/docs/index.md) (`07-message-routing.md` and `03-topologies.md` in particular).
 
+---
+
 ## Use cases
 
-**Multi-room home**: One root hub runs OVOS. Each room has a sub-hub that controls local devices. Satellites in each room connect to the sub-hub. Skills running on the root can BROADCAST to specific rooms.
+**Multi-room home**: One root hivemind-core runs OVOS. Each room has a child instance that controls local devices. Satellites in each room connect to the child instance. Skills running on the root can BROADCAST to specific rooms.
 
-**Shared household**: Two housemates each run their own OVOS instance (John and Jane). Both connect to a shared root hub (George) that controls shared smart-home devices. John and Jane route shared-home commands through George, but keep personal data (calendars, playlists) local to their own hubs.
+**Shared household**: Two housemates each run their own OVOS instance (John and Jane). Both connect to a shared root hivemind-core (George) that controls shared smart-home devices. John and Jane route shared-home commands through George, but keep personal data (calendars, playlists) local to their own instances.
 
-**Guest access**: A guest sub-hub is created temporarily under the root. Guest satellites connect to the sub-hub. The root grants the sub-hub limited permissions; when the guest leaves, the sub-hub entry is removed.
+**Guest access**: A guest instance is created temporarily under the root. Guest satellites connect to it. The root grants the guest instance limited permissions; when the guest leaves, the entry is removed.
 
 ```
-[George / Root Hub]
-    ├──→ [John's Hub] ──→ phone, personal skills
-    ├──→ [Jane's Hub] ──→ phone, personal skills
-    └──→ [Guest Hub]  ──→ voice satellites in living room
+[George / Root hivemind-core]
+    ├──→ [John's instance] ──→ phone, personal skills
+    ├──→ [Jane's instance] ──→ phone, personal skills
+    └──→ [Guest instance]  ──→ voice satellites in living room
 ```
+
+---
 
 ## Local hives (no network)
 
-A "local hive" is a hub and satellite running on the same machine. This is useful when you want separate processes communicating via the HiveMind protocol without a real network hop — for example, a skill running as a satellite that delegates some intents to another OVOS instance on the same host.
+A "local hive" is a hivemind-core instance and satellite running on the same machine. This is useful when you want separate processes communicating via the HiveMind protocol without a real network hop — for example, a skill running as a satellite that delegates some intents to another OVOS instance on the same host.
 
 ---
 
 **Next:** [Protocol](protocol.md) for the message types in detail, or [Security](security.md) for how permission chains compose across hops.
+
+---
 
 ## Source
 

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -1,8 +1,11 @@
 # Plugin Architecture
 
-In plain terms: HiveMind is built from interchangeable parts. You can swap how it talks to devices, which AI answers requests, how it handles audio, where it stores credentials, and how it decides what each device may do — each independently, without rewriting the rest.
+**HiveMind is built from interchangeable parts.** HiveMind Core is assembled from **five families** of plugins, managed by the **HiveMind Plugin Manager** (HPM), and each family is independently swappable without touching the others: how it talks to devices, which AI answers requests, how it handles audio, where it stores credentials, and how it decides what each device may do.
 
-HiveMind Core is assembled from **five families** of plugins, managed by the **HiveMind Plugin Manager** (HPM). Each family is independently swappable without touching the others.
+!!! abstract "In a nutshell"
+    - Five plugin families: network protocol, agent protocol, binary data handler, database, and policy.
+    - Defaults are the WebSocket + HTTP transports, the OVOS agent, the SQLite database, and the OVOS agent policy; no binary plugin loads by default.
+    - Plugins are wired up in `~/.config/hivemind-core/server.json`; installed package names may differ from the plugin (entry-point) names used in config.
 
 ![HPM diagram](../hpm.png)
 
@@ -20,8 +23,8 @@ Control how HiveMind listens for and connects to satellites.
 | `hivemind-usenet-wormhole` | Usenet store-and-forward | — | experimental, unpublished |
 
 WebSocket and HTTP are enabled by default in `server.json`. The MQTT plugin
-(package `hivemind-mqtt-protocol`) is published as an alpha and ships the hub-side
-listener; a satellite-side MQTT client is still planned. The Usenet wormhole
+(package `hivemind-mqtt-protocol`) is published as an alpha and ships the server-side
+listener; a satellite-side MQTT client is planned. The Usenet wormhole
 (package `hivemind-usenet`) is an experimental covert/fallback transport — not a
 real-time channel, not on PyPI (it pulls git-only carrier libraries).
 
@@ -37,7 +40,7 @@ Control which AI back-end handles incoming messages.
 
 ### Binary data handler plugins
 
-Control how binary payloads (audio, images, files) are processed on the hub.
+Control how binary payloads (audio, images, files) are processed on hivemind-core.
 
 | Plugin | Function |
 |---|---|
@@ -64,6 +67,8 @@ Control admission — what each client is allowed to do. Policy plugins are load
 | `hivemind-ovos-agent-policy` | Per-client skill/intent blacklists for the OVOS agent (default) |
 
 The built-in `allowed_types` ACL (`MessageTypeACLPolicy`) is always force-prepended to the chain and cannot be removed. See [Security — How the policy chain works](security.md#how-the-policy-chain-works) and [Writing Plugins — Policy plugins](../developers/writing-plugins.md#5-policy).
+
+---
 
 ## Configuration
 
@@ -106,6 +111,8 @@ Plugins are wired up in `~/.config/hivemind-core/server.json`. The default confi
 }
 ```
 
+---
+
 ## Installing plugins
 
 Plugins are installed as Python packages via pip:
@@ -116,6 +123,8 @@ pip install hivemind-redis-database
 ```
 
 After installation, update `server.json` to reference the new plugin (entry-point) name — note that the installed package name may differ from the plugin name used in config (e.g. the `hivemind-redis-database` package provides the `hivemind-redis-db-plugin` plugin, and `hivemind-audio-binary-protocol` provides `hivemind-audio-binary-protocol-plugin`).
+
+---
 
 ## Developing plugins
 
@@ -143,6 +152,8 @@ agent = AgentProtocolFactory.create("hivemind-ovos-agent-plugin")
 ```
 
 To author your own plugin, see [Writing Plugins](../developers/writing-plugins.md).
+
+---
 
 ## Source
 

--- a/docs/concepts/protocol.md
+++ b/docs/concepts/protocol.md
@@ -1,8 +1,11 @@
 # Protocol
 
-In plain terms: this is the shared language HiveMind nodes speak. Every message is wrapped in a small envelope that says what kind of message it is and where it should go, so hubs and satellites can route it correctly.
+**The HiveMind protocol is the shared language its nodes speak.** It runs over pluggable transports, and every message on the wire is a `HiveMessage` — a JSON envelope (or binary-encoded equivalent) carrying a `msg_type` and a payload that says what kind of message it is and where it should go, so hivemind-core instances and satellites route it correctly.
 
-HiveMind defines a message protocol that runs over pluggable transports. Every message on the wire is a `HiveMessage` — a JSON envelope (or binary-encoded equivalent in protocol v2) carrying a `msg_type` and a payload.
+!!! abstract "In a nutshell"
+    - Every message is a `HiveMessage` with a `msg_type` from the `HiveMessageType` enum: payload messages (`BUS`, `SHARED_BUS`, `THIRDPRTY`, `BINARY`), routing messages (`ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM`, `PING`), and connection messages (`HELLO`, `HANDSHAKE`).
+    - `BUS` is the workhorse: a single-hop request/response between a satellite and the AI back-end.
+    - hivemind-core injects routing and session context into each OVOS message and uses `Message.reply()` to route replies back to the right satellite.
 
 ## HiveMessage types
 
@@ -15,7 +18,7 @@ These carry OVOS `Message` objects (or other application payloads) as their cont
 | Type | Purpose | Direction |
 |---|---|---|
 | **`BUS`** | Single-hop message to/from the AI back-end | Bidirectional |
-| **`SHARED_BUS`** | Passive monitoring of a satellite's local OVOS bus | Satellite → Hub |
+| **`SHARED_BUS`** | Passive monitoring of a satellite's local OVOS bus | Satellite → hivemind-core |
 | **`THIRDPRTY`** | User-defined payload, relayed opaquely | Application-defined |
 | **`BINARY`** | Raw binary data (audio, images, files) | Bidirectional |
 
@@ -25,8 +28,8 @@ These wrap another `HiveMessage` as their payload and control how it is routed t
 
 | Type | Purpose | Direction |
 |---|---|---|
-| **`ESCALATE`** | Multi-hop upward — satellite asks parent for help | Satellite → Hub (up the chain) |
-| **`BROADCAST`** | Multi-hop downward — hub commands all satellites | Hub → All satellites (down the chain) |
+| **`ESCALATE`** | Multi-hop upward — satellite asks parent for help | Satellite → hivemind-core (up the chain) |
+| **`BROADCAST`** | Multi-hop downward — hivemind-core commands all satellites | hivemind-core → All satellites (down the chain) |
 | **`PROPAGATE`** | Flood in all directions — reaches all reachable nodes | Bidirectional |
 | **`QUERY`** | Routed request with a single expected response | Bidirectional |
 | **`CASCADE`** | Scatter/gather — every node may answer; originator picks best | Bidirectional |
@@ -43,9 +46,11 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 | **`HELLO`** | Node announcement on connection (carries node ID and public key) |
 | **`HANDSHAKE`** | Cryptographic key exchange. Protocol **v3** runs a **Noise** handshake (always-encrypted session); the legacy **v1/v2** path uses a password (salted-hash + PBKDF2) or RSA envelope. See [Security](security.md#handshake-and-encryption). |
 
+---
+
 ## Roles
 
-### Hub (listener protocol)
+### hivemind-core (listener protocol)
 
 - **Accepts**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `QUERY`, `CASCADE`, `INTERCOM`
 - **Emits**: `BUS`, `PROPAGATE`, `BROADCAST`, `QUERY`, `CASCADE`, `INTERCOM`
@@ -55,9 +60,11 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 - **Accepts**: `BUS`, `PROPAGATE`, `BROADCAST`, `QUERY`, `CASCADE`, `INTERCOM`
 - **Emits**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `QUERY`, `CASCADE`, `INTERCOM`
 
+---
+
 ## BUS message — the workhorse
 
-`BUS` is the standard single-hop request/response. A satellite wraps an OVOS `Message` in a `HiveMessage(HiveMessageType.BUS, ovos_message)` and sends it to the hub. The hub:
+`BUS` is the standard single-hop request/response. A satellite wraps an OVOS `Message` in a `HiveMessage(HiveMessageType.BUS, ovos_message)` and sends it to hivemind-core, which:
 
 1. Checks the client's `allowed_types` whitelist — if the OVOS message type is not allowed, the message is dropped
 2. Runs the configured policy chain (by default `OVOSAgentPolicy`) which injects per-client session data including skill/intent blacklists
@@ -66,15 +73,21 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 
 The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `destination` on every reply, so all downstream skill messages (`speak`, `intent.handled`, etc.) automatically carry the originating satellite's peer ID in `destination`. `hivemind-core` reads that field and routes each reply to the correct connection.
 
+---
+
 ## SHARED_BUS — passive monitoring
 
-`SHARED_BUS` lets a satellite share its own local OVOS bus with the hub passively. The hub observes but does not inject the messages into its own bus. Typically used by the [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind) skill.
+`SHARED_BUS` lets a satellite share its own local OVOS bus with hivemind-core passively. hivemind-core observes but does not inject the messages into its own bus. Typically used by the [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind) skill.
+
+---
 
 ## INTERCOM — end-to-end encrypted peer-to-peer
 
-`INTERCOM` messages are sealed in a **hybrid envelope**: a random AES-256-GCM session key is wrapped with the **recipient node's RSA public key** (PKCS#1 OAEP) and the payload is encrypted with AES-256-GCM. The envelope carries base64 fields `encrypted_key`, `ciphertext`, `tag`, `nonce`, and `signature`. Intermediate nodes — including the hub — cannot read the payload. Only the target node, which holds the corresponding RSA private key, can unwrap the session key and decrypt it. After decryption, the node verifies the sender's RSA signature (PSS over SHA-256) using the sender's public key (stored in the trust store).
+`INTERCOM` messages are sealed in a **hybrid envelope**: a random AES-256-GCM session key is wrapped with the **recipient node's RSA public key** (PKCS#1 OAEP) and the payload is encrypted with AES-256-GCM. The envelope carries base64 fields `encrypted_key`, `ciphertext`, `tag`, `nonce`, and `signature`. Intermediate nodes — including hivemind-core — cannot read the payload. Only the target node, which holds the corresponding RSA private key, can unwrap the session key and decrypt it. After decryption, the node verifies the sender's RSA signature (PSS over SHA-256) using the sender's public key (stored in the trust store).
 
 `INTERCOM` is usually the payload of a transport message (`ESCALATE` or `PROPAGATE`) so it reaches its destination through the mesh. Intermediate nodes forward it without being able to read it.
+
+---
 
 ## Request/response — QUERY
 
@@ -82,9 +95,9 @@ The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `des
 
 **Request flow:**
 
-1. A satellite wraps an OVOS `Message` in `HiveMessage(HiveMessageType.QUERY, bus_hive_message)` and sends it to the hub, including a `query_id` in the message metadata.
-2. Each hub in the chain attempts to answer from its local agent (within a timeout). If the local agent produces a response, the hub wraps it as a QUERY response and sends it back downstream.
-3. If the local agent does not answer, the hub forwards the QUERY upstream via `query_to_master`. At the top-level master with no upstream, a `hive.query.timeout` error response is returned instead.
+1. A satellite wraps an OVOS `Message` in `HiveMessage(HiveMessageType.QUERY, bus_hive_message)` and sends it to hivemind-core, including a `query_id` in the message metadata.
+2. Each instance in the chain attempts to answer from its local agent (within a timeout). If the local agent produces a response, that instance wraps it as a QUERY response and sends it back downstream.
+3. If the local agent does not answer, the instance forwards the QUERY upstream via `query_to_master`. At the top-level master with no upstream, a `hive.query.timeout` error response is returned instead.
 
 **Response envelope:**
 
@@ -99,6 +112,8 @@ A QUERY response is itself a `HiveMessage(HiveMessageType.QUERY, ...)` with `met
 
 **Relay nodes** receiving a QUERY response with `is_response = True` route it toward `originator_peer` without re-processing it as a new request.
 
+---
+
 ## Scatter/gather — CASCADE
 
 `CASCADE` is like `PROPAGATE`, but every reachable node may answer. Use it when you want to collect responses from across the hive and pick the best one — for example, asking all nodes for their current status or broadcasting a question to all connected agents.
@@ -106,7 +121,7 @@ A QUERY response is itself a `HiveMessage(HiveMessageType.QUERY, ...)` with `met
 **Request flow:**
 
 1. A satellite sends `HiveMessage(HiveMessageType.CASCADE, bus_hive_message)` with a `query_id`.
-2. Each hub that receives the CASCADE: (a) tries its local agent and, if it gets a response, sends that back as a CASCADE response; (b) forwards the CASCADE onward to all other connected peers and upstream.
+2. Each instance that receives the CASCADE: (a) tries its local agent and, if it gets a response, sends that back as a CASCADE response; (b) forwards the CASCADE onward to all other connected peers and upstream.
 3. Multiple responses can arrive at the originator from different nodes.
 
 **Response collection:**
@@ -117,13 +132,17 @@ On the client side, `CascadeAggregator` buffers responses for a configurable `ca
 
 Unlike QUERY (where responses come from a known upstream chain), CASCADE responses can originate from any node in the hive. The select callback is responsible for evaluating and choosing among responses that may come from untrusted nodes.
 
+---
+
 ## PING and topology mapping
 
 `PING` is always wrapped inside a `PROPAGATE` — it floods to all reachable nodes. There is no separate reply message type: each node that receives a `PING` re-emits *its own* `PING` (carrying the same `flood_id`), flooded onward via `PROPAGATE`. Receivers deduplicate by `flood_id` so each probe is processed once. The PING payload is `{flood_id, peer, site_id, timestamp}`. `HiveMapper` in `hivemind_core.hive_map` observes these re-emitted PINGs to build a topology map of the live hive.
 
+---
+
 ## Session and context keys
 
-When a satellite sends a BUS message, the hub injects routing metadata into `Message.context` before passing it to OVOS:
+When a satellite sends a BUS message, hivemind-core injects routing metadata into `Message.context` before passing it to OVOS:
 
 | Key | Value | Purpose |
 |---|---|---|
@@ -136,6 +155,8 @@ When a satellite sends a BUS message, the hub injects routing metadata into `Mes
 | `context["session"]["blacklisted_intents"]` | List of intent names | Enforced by `IntentService` |
 
 After `Message.reply()` is called by OVOS, `source` and `destination` are swapped, so `destination` becomes the satellite's peer ID. `HiveMindListenerProtocol.handle_internal_mycroft()` reads this field to route the response to the correct satellite connection.
+
+---
 
 ## Protocol versions
 
@@ -157,6 +178,8 @@ The server admits a connection only if it can negotiate at least `min_protocol_v
 
 !!! note "You don't negotiate v2 to send binary"
     Whether a v1/v2 connection uses binary framing is gated by the `binarize` boolean exchanged in the handshake, **not** by negotiating `ProtocolVersion.TWO` on its own. Under v3 the session is always encrypted and binary-capable. See [Protocol Spec](../developers/protocol-spec.md) for the framing and Noise details.
+
+---
 
 ## Source
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -1,20 +1,30 @@
 # Security
 
-In plain terms: every device that joins a hive proves it knows a shared password, and after that all traffic is scrambled so nobody on the network can read it. The hub also decides, per device, exactly which kinds of messages that device is allowed to send — and nothing is allowed until you say so.
+**Every device that joins a hive proves it knows a shared password, and all traffic is then encrypted.** hivemind-core also decides, per device, exactly which kinds of messages that device may send — and nothing is allowed until you grant it.
+
+!!! abstract "In a nutshell"
+    - The `access_key` is a non-secret identifier sent in the clear; the `password` is the only secret and is never transmitted — both sides derive the session key from it.
+    - Protocol v3 runs a Noise handshake (`Noise_XXpsk2_25519_ChaChaPoly_SHA256`) for an always-encrypted, forward-secret session; older clients fall back to a PBKDF2 password handshake.
+    - Permissions are fail-closed: a new client can send nothing until you `allow-msg` each message type, and the admin flag never bypasses the `allowed_types` ACL.
+    - TLS is optional defence-in-depth; HiveMind's own handshake already encrypts every payload.
 
 !!! tip "Three layers protect a HiveMind"
     1. **Handshake + encryption** — a connecting device proves it knows the password and the two sides agree on a session key without ever sending it over the wire. On protocol **v3** this is a **Noise** handshake and the whole session is encrypted end to end.
-    2. **Permissions** — the hub checks every message against a per-device allowlist; an unknown message type is dropped.
+    2. **Permissions** — hivemind-core checks every message against a per-device allowlist; an unknown message type is dropped.
     3. **Transport (TLS)** — an *optional* outer layer of standard WebSocket encryption. HiveMind's own handshake already encrypts every payload, so **TLS is not required** — it is defence-in-depth, useful mainly to hide metadata from a network observer.
+
+---
 
 ## Credentials: access key vs. password
 
 Every satellite is issued two things by `add-client`:
 
-- **`access_key`** — a **non-secret identifier**, like a username. It is sent in the clear in the WebSocket `authorization` header so the hub knows *which* client is connecting. Leaking it does not compromise the hive.
+- **`access_key`** — a **non-secret identifier**, like a username. It is sent in the clear in the WebSocket `authorization` header so hivemind-core knows *which* client is connecting. Leaking it does not compromise the hive.
 - **`password`** — the **only secret**, and it is **never transmitted**. Both sides derive the session key from it; a connecting peer that does not know the password simply fails the handshake and is disconnected. There is no password-recovery path over the wire — knowledge of the password is proven, never revealed.
 
 Because the password is the sole secret, its strength is the security of the whole hive (see [Weak-password refusal](#weak-password-refusal)).
+
+---
 
 ## Handshake and encryption
 
@@ -101,16 +111,18 @@ Reset the RSA key at any time with `hivemind-client reset-pgp` (the command name
 
 For INTERCOM (and the signed trust checks on PROPAGATE / CASCADE), a node only accepts messages from peers whose public key it has been told to trust. That trust is configured out of band: each node maintains a `trusted_keys` mapping (alias → public-key string) in its identity file. Add a peer's key with `NodeIdentity.add_trusted_key(alias, pubkey)` (and `trusted_keys` / `remove_trusted_key` to read or revoke). After PING discovery has mapped the network, `HiveMapper.mark_trusted_nodes(trusted_keys)` flips each discovered node's `trusted` flag based on that mapping, so subsequent source-trust checks resolve quickly. Keys must be exchanged through a channel you already trust — there is no automatic key acceptance.
 
+---
+
 ## Identity file
 
 The identity file at `~/.config/hivemind/_identity.json` stores all credentials a satellite needs to connect:
 
 | Field | Description |
 |---|---|
-| `access_key` | Non-secret client identifier assigned by the hub (sent in the clear, like a username) |
+| `access_key` | Non-secret client identifier assigned by hivemind-core (sent in the clear, like a username) |
 | `password` | The only secret; used to derive the session key (v3 Noise PSK, or legacy PBKDF2). Never transmitted |
-| `default_master` | Hub host address |
-| `default_port` | Hub port (default 5678 for WebSocket) |
+| `default_master` | Server host address |
+| `default_port` | Server port (default 5678 for WebSocket) |
 | `site_id` | Physical location identifier injected into OVOS context |
 | `public_key` | RSA public key string |
 | `secret_key` | Path to the RSA private key (PEM) file |
@@ -126,13 +138,15 @@ hivemind-client set-identity \
   --siteid living-room
 ```
 
+---
+
 ## Permissions
 
 Permissions in HiveMind are configured per client — there are no roles. Each client has its own `allowed_types` whitelist and per-client skill/intent blacklists.
 
 ### How the policy chain works
 
-For every message received from a satellite, the hub runs a policy admission chain:
+For every message received from a satellite, hivemind-core runs a policy admission chain:
 
 1. **`allowed_types` check** — the client's per-client whitelist is checked first. If the OVOS message type is not in the allowed list, the message is dropped immediately. This is fail-closed: a new client with an empty whitelist can send nothing.
 
@@ -142,7 +156,7 @@ Admin flag (`make-admin`) does **not** bypass the `allowed_types` check. It sign
 
 ### Writing a custom policy
 
-Admission control beyond the `allowed_types` ACL is an extension point. A custom policy is a plugin that subclasses `PolicyPlugin` (from `hivemind_plugin_manager.policy`) and is registered under the `hivemind.policy` entry-point group. The hub loads it into an ordered **policy chain** and calls it for every inbound message.
+Admission control beyond the `allowed_types` ACL is an extension point. A custom policy is a plugin that subclasses `PolicyPlugin` (from `hivemind_plugin_manager.policy`) and is registered under the `hivemind.policy` entry-point group. hivemind-core loads it into an ordered **policy chain** and calls it for every inbound message.
 
 **The contract.** Override any of three hooks:
 
@@ -172,7 +186,7 @@ When a policy denies a message, the originating client is notified on the bus wi
 }
 ```
 
-Each entry names a `module` (the entry-point name), an optional `config` dict passed to the plugin, and an optional `optional` flag. An `optional: true` policy that raises is logged and skipped (the chain continues); a mandatory policy that raises fails the chain closed. The built-in `MessageTypeACLPolicy` (the `allowed_types` ACL) is **always force-prepended** to the chain and is mandatory — it cannot be removed, made optional, or reordered, even if you list it explicitly. If the chain fails to build at startup, the hub installs a `DenyAllPolicy` fallback that rejects everything until the config is fixed.
+Each entry names a `module` (the entry-point name), an optional `config` dict passed to the plugin, and an optional `optional` flag. An `optional: true` policy that raises is logged and skipped (the chain continues); a mandatory policy that raises fails the chain closed. The built-in `MessageTypeACLPolicy` (the `allowed_types` ACL) is **always force-prepended** to the chain and is mandatory — it cannot be removed, made optional, or reordered, even if you list it explicitly. If the chain fails to build at startup, hivemind-core installs a `DenyAllPolicy` fallback that rejects everything until the config is fixed.
 
 **Minimal skeleton.** A policy plugin and its entry point:
 
@@ -242,6 +256,8 @@ hivemind-core set-metadata 2 --key role --value guest
 
 When a client is added via `add-client`, its `allowed_types` whitelist is **empty** — it is denied on every message until you explicitly `allow-msg` each message type it needs. This applies to admin clients too: the admin flag does **not** exempt a client from the `allowed_types` ACL (see *How the policy chain works* above). This deny-all-by-default posture ensures that compromised credentials give an attacker no capability until access is granted.
 
+---
+
 ## Transport security (TLS)
 
 TLS is **optional**. HiveMind's own handshake already encrypts and authenticates every payload (Noise on v3, negotiated AEAD on v1/v2), so a hive is fully secure over plain WebSocket. Add TLS only as defence-in-depth — chiefly to hide connection metadata from a passive network observer, or to satisfy an external requirement. `hivemind-core listen` takes no flags — TLS is configured in `~/.config/hivemind-core/server.json` under `network_protocol.hivemind-websocket-plugin`:
@@ -264,6 +280,8 @@ TLS is **optional**. HiveMind's own handshake already encrypts and authenticates
 
 **For internet-facing deployments**: use a reverse proxy (nginx, Caddy, Traefik) with valid certificates from Let's Encrypt. Keep HiveMind on an internal port and expose only the proxy externally. Do not expose port 5678 directly to the internet.
 
+---
+
 ## Security checklist
 
 **Local/private networks:**
@@ -281,6 +299,8 @@ TLS is **optional**. HiveMind's own handshake already encrypts and authenticates
 - [ ] Keep port 5678 unexposed to the public internet (behind the proxy only)
 - [ ] Apply rate limiting and firewall rules at the proxy
 
+---
+
 ## Limitations
 
 - Security is proportional to password entropy. Weak passwords are the primary attack surface — which is why `poorman_handshake` refuses guessable ones (see [Weak-password refusal](#weak-password-refusal)).
@@ -290,6 +310,8 @@ TLS is **optional**. HiveMind's own handshake already encrypts and authenticates
 ---
 
 **Next:** [Mesh Topology](mesh.md) for how permissions compose across nested hives, or [Writing Plugins](../developers/writing-plugins.md#5-policy) to ship a custom admission policy.
+
+---
 
 ## Source
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -22,8 +22,8 @@ Because the password is the sole secret, its strength is the security of the who
 
 Protocol **v3** replaces the legacy handshake with the **[Noise Protocol Framework](https://noiseprotocol.org/)**. A v3-capable client (Noise primitive available and a password configured) negotiates an always-encrypted, forward-secret session:
 
-- **Default suite:** `Noise_XXpsk2_25519_ChaChaPoly_SHA256` — mutual static-key authentication over X25519, per-handshake ephemeral Diffie-Hellman (forward secrecy), ChaCha20-Poly1305 AEAD, SHA-256. A `Noise_XXpsk2_25519_AESGCM_SHA256` suite is also offered for **Web Crypto / JavaScript** peers that only expose AES-GCM.
-- **PSK derivation:** the shared secret mixed into the handshake is `PSK = argon2id(password, salt = SHA-256(node_id))`. Salting with the server's `node_id` makes the PSK server-specific, so the same password on two servers yields two different PSKs.
+- **Default suite:** `Noise_XXpsk2_25519_ChaChaPoly_SHA256` — mutual static-key authentication over X25519, per-handshake ephemeral Diffie-Hellman (forward secrecy), ChaCha20-Poly1305 AEAD, SHA-256. This is the suite browser and JavaScript clients ([HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)) negotiate too: they pair the native Web Crypto API with the pure-JS [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) + [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) for the two primitives Web Crypto lacks (ChaCha20-Poly1305 and argon2id), giving **full cipher parity with hivemind-core** — no server-side configuration required. A `Noise_XXpsk2_25519_AESGCM_SHA256` suite is also registered as an AES-GCM alternative for minimal Web-Crypto-only peers (see the browser caveat below).
+- **PSK derivation:** the shared secret mixed into the handshake is `PSK = argon2id(password, salt = SHA-256(node_id))`. Salting with the server's `node_id` makes the PSK server-specific, so the same password on two servers yields two different PSKs. A full browser client derives this **in-browser** with `@noble/hashes` argon2id (same parameters as the server), so a password alone is enough — no provisioning and no server-side KDF change. A pre-provisioned 32-byte `psk` remains an option, and PBKDF2 remains an explicit fallback when a server advertises it.
 - **Pinned-key case:** once a client's static key has been pinned by a prior `XXpsk2` handshake, both ends may use `Noise_KKpsk0_25519_ChaChaPoly_SHA256` (both static keys known in advance).
 - Only `HELLO` and `HANDSHAKE` frames travel unencrypted (they precede session-key establishment). On a `crypto_required` server, any other cleartext frame is rejected and the client disconnected.
 
@@ -35,6 +35,9 @@ Protocol **v3** replaces the legacy handshake with the **[Noise Protocol Framewo
     ```
 
     This prints the hex PSK, which equals `argon2id(password, SHA-256(node_id))` — identical to what a capable peer derives at connect time, so a provisioned device and a password-deriving device interoperate with no server-side distinction. The device never sees the password itself.
+
+!!! note "Browser caveat"
+    Browsers are **not** constrained: with `@noble` loaded (a five-line ESM shim exposing `chacha20poly1305` + `argon2id` on `globalThis.HiveMindNoble`) a HiveMind-js client negotiates the default ChaChaPoly suite and derives the argon2id PSK on-device, exactly like a Python client. Only a **minimal** browser bundle shipped *without* `@noble` degrades to the AES-GCM + PBKDF2 subset, and then needs either a provisioned `psk` or a PBKDF2-advertising server.
 
 ### Legacy handshake (protocol v1 / v2)
 

--- a/docs/developers/client-library.md
+++ b/docs/developers/client-library.md
@@ -1,8 +1,18 @@
 # Developer Guide — Client Library
 
-> **New here?** This page is for writing a program that talks to a HiveMind hub. If you just want to *use* a satellite, see [Choosing a Satellite](../satellites/index.md) instead — you only need this if you are building your own client in Python.
+**`hivemind-bus-client` (repo: `hivemind-websocket-client`) is the primary Python library for building HiveMind clients.** It handles connection management, the PBKDF2 handshake, AES-256-GCM encryption, and serialization transparently.
 
-`hivemind-bus-client` (repo: `hivemind-websocket-client`) is the primary Python library for building HiveMind clients. It handles connection management, the PBKDF2 handshake, AES-256-GCM encryption, and serialization transparently.
+!!! abstract "In a nutshell"
+    - Connect to hivemind-core from Python with `HiveMessageBusClient`, send/receive OVOS messages, and let the library handle the handshake, encryption, and serialization.
+    - Sync (thread-based), async (`asyncio`), and HTTP (polling) clients share the same message API; only the sync client reconnects on its own.
+    - Higher-level helpers cover blocking request/response, binary audio, topology discovery, CASCADE aggregation, end-to-end INTERCOM, and trusted-key identity.
+
+!!! note "Building your own client in Python?"
+    This page is for writing a program that talks to a hivemind-core server. To simply *use* a satellite, see [Choosing a Satellite](../satellites/index.md) instead.
+
+`hivemind-bus-client` is available on [PyPI](https://pypi.org/project/hivemind-bus-client) and [GitHub](https://github.com/JarbasHiveMind/hivemind_websocket_client).
+
+---
 
 ## Install
 
@@ -10,13 +20,17 @@
 pip install hivemind-bus-client
 ```
 
+---
+
 ## Libraries
 
 | Library | Language | Notes |
 |---|---|---|
 | [hivemind-bus-client](https://github.com/JarbasHiveMind/hivemind_websocket_client) | Python | Primary client; WebSocket + HTTP + async + MQTT |
 | [HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js) | JavaScript | Browser and Node.js |
-| [ovos-solver-hivemind-plugin](https://github.com/JarbasHiveMind/ovos-solver-hivemind-plugin) | Python | OVOS solver plugin — chat with a HiveMind hub |
+| [ovos-solver-hivemind-plugin](https://github.com/JarbasHiveMind/ovos-solver-hivemind-plugin) | Python | OVOS solver plugin — chat with a hivemind-core server |
+
+---
 
 ## Basic connection
 
@@ -40,6 +54,8 @@ client = HiveMessageBusClient(
 client.connect()
 ```
 
+---
+
 ## Sending utterances
 
 ```python
@@ -54,6 +70,8 @@ msg = HiveMessage(
 client.emit(msg)
 ```
 
+---
+
 ## Handling responses
 
 ```python
@@ -62,6 +80,8 @@ def handle_speak(message):
 
 client.on_mycroft("speak", handle_speak)
 ```
+
+---
 
 ## Conversational loop
 
@@ -92,12 +112,16 @@ while True:
 
 The synchronous `HiveMessageBusClient` runs its WebSocket on a background thread; there is no `close()` method — interrupting the loop is enough to stop sending. (An explicit `close()` exists only on the async client in `hivemind_bus_client.async_client`.)
 
+---
+
 ## Sending binary data (audio)
 
 ```python
 audio_bytes = b"..."  # Raw PCM data
 client.emit(HiveMessage(HiveMessageType.BINARY, audio_bytes))
 ```
+
+---
 
 ## HTTP client
 
@@ -109,6 +133,8 @@ from hivemind_bus_client.http_client import HiveMindHTTPClient
 client = HiveMindHTTPClient(host="http://192.168.1.10", port=5679)
 client.connect()
 ```
+
+---
 
 ## Identity management
 
@@ -127,6 +153,8 @@ hivemind-client test-identity
 
 The identity file is at `~/.config/hivemind/_identity.json`.
 
+---
+
 ## Receiving binary data
 
 Inbound binary payloads (TTS audio, files) are dispatched through a
@@ -144,13 +172,15 @@ class MyBinaryHandler(BinaryDataCallbacks):
             f.write(bin_data)
 
     def handle_receive_file(self, bin_data: bytes, file_name: str):
-        # arbitrary file pushed from the hub
+        # arbitrary file pushed from hivemind-core
         with open(file_name, "wb") as f:
             f.write(bin_data)
 
 client = HiveMessageBusClient(bin_callbacks=MyBinaryHandler())
 client.connect()
 ```
+
+---
 
 ## Serialization and encryption
 
@@ -160,6 +190,8 @@ client.connect()
 2. The payload is compressed with zlib if enabled
 3. The result is encrypted with AES-256-GCM using the session key
 4. The encrypted payload is encoded (Z85 + Base91) for text transport
+
+---
 
 ## Decorator helpers
 
@@ -184,6 +216,8 @@ Other decorators target specific `HiveMessageType` envelopes:
 `on_hive_message`, `on_payload`, `on_ping`, `on_broadcast`, `on_propagate`,
 `on_escalate`, `on_handshake`, `on_hello`, `on_query`, `on_cascade`,
 `on_rendezvous`, `on_third_party`, and `on_shared_bus`.
+
+---
 
 ## Topology mapping (PING flood)
 
@@ -222,6 +256,8 @@ For automated topology collection use `HiveMapper` from
 `hivemind_bus_client.hive_map`. Call `mapper.start_ping(flood_id)`, feed each
 received inner `PING` to `mapper.on_ping(ping_msg)`, and read back the discovered
 `mapper.nodes` / `mapper.edges`.
+
+---
 
 ## Request / response
 
@@ -271,6 +307,8 @@ if reply is not None:
 The same five helpers exist on the async client as coroutines — `await
 client.wait_for_response(...)`.
 
+---
+
 ## INTERCOM — end-to-end satellite-to-satellite
 
 `emit_intercom` sends a message addressed to one specific peer, encrypted so that
@@ -289,7 +327,7 @@ base64 fields `encrypted_key`, `ciphertext`, `tag`, `nonce`, and `signature`,
 wrapped in a `HiveMessageType.INTERCOM` message.
 
 ```python
-recipient_pubkey = client.identity.trusted_keys["living-room-hub"]
+recipient_pubkey = client.identity.trusted_keys["living-room-satellite"]
 client.emit_intercom(
     HiveMessage(HiveMessageType.BUS,
                 Message("speak", {"utterance": "psst"})),
@@ -307,6 +345,8 @@ accepted.
 > `encrypt_RSA(pubkey, ...)`, signs it, and sends a payload of just
 > `{"ciphertext": ..., "signature": ...}` (both base64). Don't mix the two
 > formats across transports.
+
+---
 
 ## Async client
 
@@ -352,6 +392,8 @@ Use the async client when your app already runs an event loop (aiohttp/FastAPI,
 discord.py, etc.). Use the sync `HiveMessageBusClient` for scripts and
 thread-based apps — it runs its WebSocket on a background thread and needs no loop.
 
+---
+
 ## HTTP client specifics
 
 `HiveMindHTTPClient` (`hivemind_bus_client.http_client`) is a
@@ -376,6 +418,8 @@ resp = client.emit(some_hive_message)    # returns a requests.Response
   `on_mycroft(ovos_type, func)` for inner OVOS messages; `remove` /
   `remove_mycroft` unregister them.
 - `disconnect()` (POST `/disconnect`) and `shutdown()` stop the loop.
+
+---
 
 ## CASCADE aggregation
 
@@ -404,6 +448,8 @@ Inside `HiveMindSlaveProtocol.handle_cascade`, a node builds one per query:
 known to the `HiveMapper`, and `emit_callback` injects the winner's inner BUS
 payload onto the internal bus.
 
+---
+
 ## Identity & trusted keys
 
 `NodeIdentity` (`hivemind_bus_client.identity`) wraps the identity file
@@ -415,7 +461,7 @@ payload onto the internal bus.
 ```python
 identity = NodeIdentity()
 identity.create_keys()                       # generate + store an RSA keypair
-identity.add_trusted_key("living-room-hub",  # alias -> public key
+identity.add_trusted_key("living-room-satellite",  # alias -> public key
                          peer_public_key)     # True if added, False if alias exists
 identity.save()                              # persist to the identity file
 identity.reload()                            # re-read from disk
@@ -427,6 +473,8 @@ CASCADE, and INTERCOM handling — only messages from a trusted key (or explicit
 targeted at this node) are injected onto the bus. Related helpers:
 `remove_trusted_key(alias)`, `is_trusted_key(pubkey)`,
 `get_trusted_alias(pubkey)`.
+
+---
 
 ## Reconnection
 
@@ -443,6 +491,8 @@ and needs resilience against dropped connections, build your own supervisor:
 detect the drop (e.g. emit failures, the async receive loop emitting `"close"`,
 or your own heartbeat) and re-run `connect()` on a fresh client with backoff.
 
+---
+
 ## Encodings & ciphers
 
 The JSON transport encoding and the symmetric cipher are configurable. The enums
@@ -456,9 +506,8 @@ live in `hivemind_bus_client.encryption`:
 `SupportedCiphers`: `AES_GCM` (`"AES-GCM"`), `CHACHA20_POLY1305`
 (`"CHACHA20-POLY1305"`).
 
-Clients default to `JSON_HEX` + `AES_GCM` (the server defaults before they became
-configurable; the actual values are negotiated during the handshake). To force
-them, set the attributes after construction:
+Clients default to `JSON_HEX` + `AES_GCM`; the actual values in use are negotiated
+during the handshake. To force them, set the attributes after construction:
 
 ```python
 from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers
@@ -469,16 +518,15 @@ client.cipher = SupportedCiphers.CHACHA20_POLY1305
 client.connect()
 ```
 
-## Next
-
-- [Protocol Specification](protocol-spec.md) — wire format, message types, routing
-- [Testing Guide](testing.md) — writing tests with the in-process harness
+---
 
 ## See also
 
-- [Protocol Reference](protocol-spec.md) — wire format, message types, routing
+- [Protocol Specification](protocol-spec.md) — wire format, message types, routing
 - [Testing Guide](testing.md) — writing tests with the in-process harness
 - [CLI Reference](../reference/cli.md) — `hivemind-client` commands
+
+---
 
 ## Source
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,13 +1,15 @@
 # Developer Guide
 
-This section is for people **writing code against HiveMind** — building a custom
+**The Developer Guide is for writing code against HiveMind** — building a custom
 satellite, embedding a client in an app, implementing a new transport or backend, or
 testing a protocol implementation.
 
 !!! tip "Not a developer? You can skip this whole section."
-    Running a hub and connecting off-the-shelf satellites needs no code — see
+    Running hivemind-core and connecting off-the-shelf satellites needs no code — see
     [Quick Start](../quickstart.md) and [Satellites](../satellites/index.md). Come back
     here when you want to build something new.
+
+---
 
 ## What's in this section
 
@@ -16,7 +18,9 @@ testing a protocol implementation.
 | [Client Library](client-library.md) | Connect to a hive from Python — send/receive messages, handle encryption, reconnect. |
 | [Protocol Specification](protocol-spec.md) | Implement HiveMind in another language, or understand the exact wire format byte-for-byte. |
 | [Writing Plugins](writing-plugins.md) | Add a new transport, agent backend, database, or permission policy. |
-| [Testing](testing.md) | Write end-to-end tests for satellites, hubs, or whole mesh topologies. |
+| [Testing](testing.md) | Write end-to-end tests for satellites, hivemind-core, or whole mesh topologies. |
+
+---
 
 ## Which layer are you extending?
 

--- a/docs/developers/protocol-spec.md
+++ b/docs/developers/protocol-spec.md
@@ -28,7 +28,7 @@ Within the **v1/v2** (legacy handshake) family, binary framing is **not** gated 
 | **v0** | JSON | Pre-shared AES key only (legacy, deprecated) | None |
 | **v1** | JSON (and binary framing when `binarize` is negotiated) | Handshake: PBKDF2 password **or** RSA | Optional zlib |
 | **v2** | JSON + binary framing | Handshake: PBKDF2 password **or** RSA | Optional zlib |
-| **v3** | Binary framing, always encrypted | **Noise** (`Noise_XXpsk2_25519_ChaChaPoly_SHA256` default; `AESGCM` suite for Web Crypto peers; `KKpsk0` when the static key is pinned). PSK = `argon2id(password, SHA-256(node_id))` | Optional zlib |
+| **v3** | Binary framing, always encrypted | **Noise** (`Noise_XXpsk2_25519_ChaChaPoly_SHA256` default — negotiated by browser/JS clients too via `@noble`; `AESGCM` suite as a fallback for minimal Web-Crypto-only peers; `KKpsk0` when the static key is pinned). PSK = `argon2id(password, SHA-256(node_id))`, derived in-browser | Optional zlib |
 
 !!! note "v3 Noise wire format"
     The byte-level Noise handshake sequence (message tokens, prologue binding of the `HELLO`/`HANDSHAKE` payloads, PSK slot, and the provisioned-PSK path for constrained devices) is defined by `hivemind_bus_client/noise.py` and `poorman_handshake/noise/`. The [Security](../concepts/security.md#protocol-v3-the-noise-handshake-current-default) page covers the model; a full independent-implementer byte spec for v3 is tracked as follow-up. The v1/v2 state machine below remains authoritative for the legacy handshake.

--- a/docs/developers/protocol-spec.md
+++ b/docs/developers/protocol-spec.md
@@ -1,10 +1,17 @@
 # Protocol Specification
 
-> **Who needs this page?** Only if you are implementing a HiveMind client from scratch in a language without an official library, or debugging the wire format. If you are using the Python or JS client, the library already does everything described here — start with the [Client Library](client-library.md) instead.
+**The HiveMind protocol is the byte-level wire format for `HiveMessage` traffic** — the message envelope, the negotiated handshake, encryption, and the optional binary framing enabled by the `binarize` capability.
 
-This page describes the wire format for HiveMind messages, including the binary framing that is enabled by the `binarize` capability negotiated during the handshake.
+!!! abstract "In a nutshell"
+    - Every message is a `HiveMessage` (`msg_type`, `payload`, `context`); `BUS` messages carry OVOS `Message` objects.
+    - The session `ProtocolVersion` is negotiated at connect time: v1/v2 use a password or RSA handshake, v3 uses a Noise handshake and is always encrypted.
+    - The [handshake state machine](#handshake-state-machine) and [negotiation defaults](#negotiation-defaults) are sufficient to bring an independent client to a fully-encrypted, session-established state.
+    - `binarize` is a per-connection capability, not a version bump: it packs messages into a compact binary frame instead of JSON.
 
-If you are implementing an independent (non-Python) client, read the [Handshake state machine](#handshake-state-machine) and [Negotiation & defaults](#negotiation-defaults) sections below first — they are written to be sufficient to bring a client to a fully-encrypted, session-established state without reading the reference implementation.
+!!! note "Using the Python or JS client?"
+    The library already implements everything on this page. Read it only to implement a HiveMind client from scratch in another language, or to debug the wire format; otherwise start with the [Client Library](client-library.md).
+
+---
 
 ## Message envelope
 
@@ -13,6 +20,8 @@ Every HiveMind message is a `HiveMessage` with:
 - `msg_type` — a `HiveMessageType` enum value (see [Protocol Concepts](../concepts/protocol.md))
 - `payload` — the message content (an OVOS `Message` object, a nested `HiveMessage`, or raw bytes)
 - `context` — optional routing metadata dict
+
+---
 
 ## Protocol versions
 
@@ -31,7 +40,9 @@ Within the **v1/v2** (legacy handshake) family, binary framing is **not** gated 
 | **v3** | Binary framing, always encrypted | **Noise** (`Noise_XXpsk2_25519_ChaChaPoly_SHA256` default — negotiated by browser/JS clients too via `@noble`; `AESGCM` suite as a fallback for minimal Web-Crypto-only peers; `KKpsk0` when the static key is pinned). PSK = `argon2id(password, SHA-256(node_id))`, derived in-browser | Optional zlib |
 
 !!! note "v3 Noise wire format"
-    The byte-level Noise handshake sequence (message tokens, prologue binding of the `HELLO`/`HANDSHAKE` payloads, PSK slot, and the provisioned-PSK path for constrained devices) is defined by `hivemind_bus_client/noise.py` and `poorman_handshake/noise/`. The [Security](../concepts/security.md#protocol-v3-the-noise-handshake-current-default) page covers the model; a full independent-implementer byte spec for v3 is tracked as follow-up. The v1/v2 state machine below remains authoritative for the legacy handshake.
+    The v1/v2 state machine below is the authoritative byte-level reference for the legacy handshake. The v3 Noise wire format — message tokens, prologue binding of the `HELLO`/`HANDSHAKE` payloads, PSK slot, and the provisioned-PSK path for constrained devices — is defined by the `hivemind_bus_client/noise.py` and `poorman_handshake/noise/` source modules; the [Security](../concepts/security.md#protocol-v3-the-noise-handshake-current-default) page covers its model.
+
+---
 
 ## Handshake state machine
 
@@ -141,6 +152,8 @@ On receipt the client derives `crypto_key`:
 
 > Note: a client requesting `session_id == "default"` is disconnected unless it is an administrator.
 
+---
+
 ## Negotiation & defaults
 
 ### Default encoding is `JSON_HEX`, not `JSON_B64`
@@ -206,6 +219,8 @@ The session key math lives in the external **`poorman_handshake`** package, not 
 - The receiver strips the signature (first `key_size_in_bytes` bytes), RSA-decrypts the remainder with its private key to recover the 32-byte `secret`, and (in `receive_and_verify`) first verifies the PSS signature against the known peer public key.
 - That 32-byte `secret` becomes `crypto_key`. No PBKDF2 is involved in RSA mode.
 
+---
+
 ## Binary framing
 
 When both sides negotiate `binarize: true` in the handshake, messages are framed in a compact binary format instead of JSON. This is a per-connection capability flag, not a protocol-version increment — the wire `ProtocolVersion` remains `ONE`.
@@ -259,7 +274,7 @@ For `BINARY` (`msg_type = 12`) messages, a 4-bit unsigned integer immediately af
 | 3 | FILE | File transfer; see context for filename |
 | 4 | STT_AUDIO_TRANSCRIBE | Full audio utterance — return transcript only |
 | 5 | STT_AUDIO_HANDLE | Full audio utterance — transcribe and handle intent |
-| 6 | TTS_AUDIO | Synthesized speech audio (hub → satellite) |
+| 6 | TTS_AUDIO | Synthesized speech audio (hivemind-core → satellite) |
 
 ### Versioned vs unversioned framing
 
@@ -289,13 +304,19 @@ The `versioned` bit is **0** by default in the reference encoder (`get_bitstring
 - `0001` — RAW_AUDIO binary payload type
 - `<audio_bytes>` — PCM audio data
 
+---
+
 ## Compression
 
 When the compression flag is set, both the metadata and payload are compressed independently with zlib (each typically ~49–50% smaller). Compression is most effective on large payloads; it adds overhead for small messages.
 
+---
+
 ## Session context
 
-See [Protocol Concepts — Session and context keys](../concepts/protocol.md#session-and-context-keys) for the full reference of keys injected into `Message.context` by the hub.
+See [Protocol Concepts — Session and context keys](../concepts/protocol.md#session-and-context-keys) for the full reference of keys injected into `Message.context` by hivemind-core.
+
+---
 
 ## OVOS messages (payload format)
 
@@ -318,6 +339,8 @@ OVOS `Message` objects are the standard payload for `BUS` messages. The structur
 
 The full OVOS message specification is maintained at [OpenVoiceOS/message_spec](https://github.com/OpenVoiceOS/message_spec).
 
+---
+
 ## Transports
 
 The protocol runs over any transport that can carry byte streams:
@@ -329,11 +352,12 @@ The protocol runs over any transport that can carry byte streams:
 | MQTT (broker) | `hivemind-mqtt-plugin` | 1883 |
 | Usenet wormhole | `hivemind-usenet-wormhole` | — |
 
-WebSocket/HTTP are stable defaults. MQTT (package `hivemind-mqtt-protocol`) is a
-published alpha with a complete hub listener; its satellite client is still
-planned. The Usenet wormhole (package `hivemind-usenet`) is experimental and
-unpublished — a high-latency covert/fallback control-plane, not a real-time
-transport.
+WebSocket and HTTP are the stable defaults. MQTT (package `hivemind-mqtt-protocol`)
+is a published alpha providing a complete hivemind-core listener without a satellite client.
+The Usenet wormhole (package `hivemind-usenet`) is experimental and unpublished — a
+high-latency covert/fallback control-plane, not a real-time transport.
+
+---
 
 ## Source
 

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -1,15 +1,16 @@
 # Testing Guide
 
-[`hivescope`](https://github.com/JarbasHiveMind/hivescope) is the in-process E2E
-testing library for HiveMind. It wires `MasterNode`, `SatelliteNode`, and
-`RelayNode` objects together directly — no real sockets, no running servers, no
-network processes — and records every `HiveMessage` for inspection. Use it to
-validate message routing, session handling, ACL enforcement, and protocol
-compliance.
+**[`hivescope`](https://github.com/JarbasHiveMind/hivescope) is the in-process end-to-end testing library for HiveMind.** It wires `MasterNode`, `SatelliteNode`, and `RelayNode` objects together directly — no real sockets, no running servers, no network processes — and records every `HiveMessage` for inspection.
 
-(`hivemind-test-harness` builds on top of hivescope for cross-repo stress and
-multi-topology suites; for testing a single client or skill, target hivescope
-directly.)
+!!! abstract "In a nutshell"
+    - Assemble a test topology from `MasterNode`, `SatelliteNode`, and `RelayNode` objects to validate message routing, session handling, ACL enforcement, and protocol compliance.
+    - Every node carries a `MessageRecorder`; the master's `TestAgentProtocol` records every OVOS message injected onto its agent bus.
+    - `hivescope.scenarios` ships pre-wired topology builders and `hivescope.assertions` ships ready-made checks; `pytest` fixtures wire the common ones up automatically.
+
+`hivemind-test-harness` builds on top of hivescope for cross-repo stress and
+multi-topology suites; to test a single client or skill, target hivescope directly.
+
+---
 
 ## Install
 
@@ -24,11 +25,13 @@ For OVOS skill-level tests backed by a live MiniCroft instance, install the
 pip install "hivescope[ovos]" pytest
 ```
 
+---
+
 ## Overview
 
 A test topology is assembled by a `TopologyBuilder` and made of nodes:
 
-- **`MasterNode`** — wraps the `HiveMindListenerProtocol` (the hub). Its
+- **`MasterNode`** — wraps the `HiveMindListenerProtocol` (hivemind-core). Its
   `agent_protocol` is a `TestAgentProtocol` that records every OVOS message
   injected onto the agent bus.
 - **`SatelliteNode`** — simulates a connected satellite client (slave protocol)
@@ -44,10 +47,12 @@ and outbound `HiveMessage`s as `RecordedMessage` entries.
 **not-yet-started** builder — call `.start_all()` before testing and
 `.stop_all()` in a `finally` block.
 
-## Pattern A: Direct hub injection
+---
+
+## Pattern A: Direct hivemind-core injection
 
 Emit an OVOS message on the master's agent bus and assert it was seen there
-(`emit_on_bus` simulates a skill response on the hub).
+(`emit_on_bus` simulates a skill response on hivemind-core).
 
 ```python
 from hivescope import TopologyBuilder
@@ -67,7 +72,9 @@ def test_direct_injection():
         b.stop_all()
 ```
 
-## Pattern B: Satellite-to-hub round-trip
+---
+
+## Pattern B: Satellite-to-hivemind-core round-trip
 
 Send a `BUS` message from a satellite and assert the master injected the inner
 OVOS utterance onto its agent bus. `single_satellite(allowed_types=[...])` grants
@@ -94,6 +101,8 @@ def test_satellite_roundtrip():
     finally:
         b.stop_all()
 ```
+
+---
 
 ## Pattern C: Multi-satellite topology
 
@@ -126,10 +135,12 @@ def test_downstream_routing():
         b.stop_all()
 ```
 
+---
+
 ## Pattern D: Session and context verification
 
 Attach an OVOS `Session` to the outgoing message and assert it survives injection
-on the hub.
+on hivemind-core.
 
 ```python
 from hivescope.scenarios import single_satellite
@@ -156,6 +167,8 @@ def test_session_propagation():
         b.stop_all()
 ```
 
+---
+
 ## Pytest fixtures
 
 Enable hivescope's fixtures from your `tests/conftest.py`:
@@ -180,6 +193,8 @@ def test_with_fixtures(master_node, restricted_satellite):
         "recognizer_loop:utterance", count=1
     )
 ```
+
+---
 
 ## Common assertions
 
@@ -207,6 +222,8 @@ from hivescope.assertions import (
 assert_bus_message_routed(m, count=1)
 ```
 
+---
+
 ## Message flow in tests
 
 ```
@@ -229,6 +246,8 @@ SatelliteNode.recorder records it; SatelliteNode.internal_bus fires
 Test assertion (recorder / agent_protocol.injected / assertions.*)
 ```
 
+---
+
 ## CI integration
 
 ```yaml
@@ -249,6 +268,8 @@ jobs:
       - run: pytest tests/ -v --cov=mypackage --cov-report=term-missing
 ```
 
+---
+
 ## Running locally
 
 ```bash
@@ -265,15 +286,15 @@ pytest tests/ -v --cov=mypackage --cov-report=term-missing
 pytest tests/test_routing.py -v
 ```
 
-## Next
-
-- [Client Library](client-library.md) — `HiveMessageBusClient` API
-- [Writing Plugins](writing-plugins.md) — building HiveMind plugins
+---
 
 ## See also
 
-- [Protocol Concepts](../concepts/protocol.md) — message types and routing
 - [Client Library](client-library.md) — `HiveMessageBusClient` API
+- [Writing Plugins](writing-plugins.md) — building HiveMind plugins
+- [Protocol Concepts](../concepts/protocol.md) — message types and routing
+
+---
 
 ## Source
 

--- a/docs/developers/writing-plugins.md
+++ b/docs/developers/writing-plugins.md
@@ -1,11 +1,16 @@
 # Writing Plugins
 
-> **What this is for.** HiveMind has no hard-coded transport, AI backend, or database — each is a swappable plugin. Read this page when you want to add a new one (e.g. a transport HiveMind doesn't ship, or your own AI backend). If you only want to *configure* existing plugins, see [Plugin Architecture](../concepts/plugins.md) instead.
+**HiveMind Core is assembled entirely from plugins discovered at runtime by the HiveMind Plugin Manager (HPM)** — no transport, AI backend, or database is hard-coded, so each is added by authoring a plugin. This is the developer-facing companion to the operator view in [Plugin Architecture](../concepts/plugins.md).
 
-HiveMind Core is assembled entirely from plugins discovered at runtime by the
-**HiveMind Plugin Manager** (HPM) — see [Plugin Architecture](../concepts/plugins.md)
-for the operator-facing view. This page is the developer-facing companion: how to
-author your own plugin for each of the five families.
+!!! abstract "In a nutshell"
+    - Five plugin families cover the extension points: network protocol, agent protocol, binary data handler, database, and policy.
+    - Authoring a plugin is two steps: subclass the family's base class and implement its contract, then register the class under the family's entry-point group.
+    - Every protocol base derives from a shared `_SubProtocol` dataclass, so each plugin receives `config`, `hm_protocol`, `identity`, `database`, `clients`, and `callbacks` for free.
+
+!!! note "Only configuring existing plugins?"
+    To select and configure installed plugins rather than author a new one, see [Plugin Architecture](../concepts/plugins.md).
+
+---
 
 ## The plugin-manager model
 
@@ -43,10 +48,10 @@ Every protocol base derives from a shared `_SubProtocol` dataclass
 (`hivemind_plugin_manager/protocols.py`) and so receives, for free:
 
 - `self.config` — the plugin's config dict
-- `self.hm_protocol` — the `HiveMindListenerProtocol` (the hub) once wired up
+- `self.hm_protocol` — the `HiveMindListenerProtocol` (hivemind-core) once wired up
 - `self.identity` — the node `NodeIdentity`
-- `self.database` — the active client `AbstractDB`, via the hub
-- `self.clients` — the connected `HiveMindClientConnection` map, via the hub
+- `self.database` — the active client `AbstractDB`, via hivemind-core
+- `self.clients` — the connected `HiveMindClientConnection` map, via hivemind-core
 - `self.callbacks` — `ClientCallbacks` (`on_connect` / `on_disconnect` /
   `on_invalid_key` / `on_invalid_protocol`)
 
@@ -55,7 +60,7 @@ Every protocol base derives from a shared `_SubProtocol` dataclass
 ## 1. Network protocol
 
 A network protocol is the transport: it accepts satellite connections and feeds
-their `HiveMessage` traffic into the hub.
+their `HiveMessage` traffic into hivemind-core.
 
 - **Entry-point group:** `hivemind.network.protocol`
 - **Base class:** `NetworkProtocol` (`hivemind_plugin_manager/protocols.py`)
@@ -68,10 +73,10 @@ their `HiveMessage` traffic into the hub.
   ```
 
   `run()` starts the transport (bind a socket / start a server loop) and keeps it
-  running, accepting client connections and dispatching their messages to the hub.
+  running, accepting client connections and dispatching their messages to hivemind-core.
   It is invoked by `NetworkProtocolFactory.create(...)` consumers in
   `hivemind-core`. In addition to the shared `_SubProtocol` members, a network
-  protocol exposes `self.agent_protocol` (the active `AgentProtocol`, via the hub).
+  protocol exposes `self.agent_protocol` (the active `AgentProtocol`, via hivemind-core).
 
 Real implementation: `hivemind-websocket-protocol`
 (`HiveMindWebsocketProtocol`, a Tornado WebSocket server).
@@ -186,7 +191,7 @@ class MyAgentProtocol(AgentProtocol):
 ## 3. Binary data handler
 
 A binary data handler processes binary `HiveMessage` payloads — raw audio, images,
-files — on the hub (server-side wakeword/STT/VAD/TTS, camera frames, etc.).
+files — on hivemind-core (server-side wakeword/STT/VAD/TTS, camera frames, etc.).
 
 - **Entry-point group:** `hivemind.binary.protocol`
 - **Base class:** `BinaryDataHandlerProtocol` (`hivemind_plugin_manager/protocols.py`)
@@ -424,6 +429,8 @@ class MyPolicy(PolicyPlugin):
 
 - [Plugin Architecture](../concepts/plugins.md) — how operators select and configure
   installed plugins in `server.json`.
+
+---
 
 ## Source
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,50 +1,57 @@
 # Frequently Asked Questions
 
-Short answers with links to the full pages. New to the vocabulary? Keep the
+**This page gives short answers with links to the full pages.** New to the vocabulary? Keep the
 [Glossary](reference/glossary.md) open in another tab.
+
+!!! abstract "In a nutshell"
+    - Quick answers grouped by topic: general concepts, setup, security, satellites, integration, and troubleshooting.
+    - Each answer links to the page that covers it in depth.
+    - Start with the [Quick Start](quickstart.md) or [Admin Panel](server/admin-panel.md) to get hivemind-core running.
 
 ## General
 
 ??? question "What is HiveMind?"
     HiveMind is an open-source protocol and platform that connects lightweight
     **[satellite](reference/glossary.md#roles)** devices (a microphone, a browser tab, a
-    terminal) to a central AI **[hub](reference/glossary.md#roles)** over an encrypted
-    network. The hub does the heavy lifting — skills, reasoning, speech-to-text — so the
+    terminal) to a central AI server — **[hivemind-core](reference/glossary.md#roles)** — over an encrypted
+    network. hivemind-core does the heavy lifting — skills, reasoning, speech-to-text — so the
     satellites can be cheap and simple. See [About](about.md).
 
 ??? question "How is it different from a single-device voice assistant?"
-    The work is **distributed**. One capable hub serves many lightweight satellites, each
+    The work is **distributed**. One capable hivemind-core server serves many lightweight satellites, each
     with its own session and permissions. Speech processing can happen on the satellite or
-    on the hub, depending on which satellite you choose ([comparison](satellites/index.md)).
+    on the server, depending on which satellite you choose ([comparison](satellites/index.md)).
 
 ??? question "Which AI backend does it use?"
-    HiveMind is **backend-agnostic**. By default the hub runs
+    HiveMind is **backend-agnostic**. By default hivemind-core runs
     [OpenVoiceOS](reference/glossary.md#ovos-voice-vocabulary) skills, but you can instead
-    point it at an LLM/chatbot ([Persona Hub](server/persona-hub.md)) or an external agent
-    ([A2A Hub](server/a2a-hub.md)). The choice is just *which
-    [agent plugin](concepts/plugins.md)* the hub loads.
+    point it at an LLM/chatbot ([Persona Server](server/persona-hub.md)) or an external agent
+    ([A2A Server](server/a2a-hub.md)). The choice is just *which
+    [agent plugin](concepts/plugins.md)* hivemind-core loads.
 
 ??? question "Do satellites talk directly to each other?"
-    No. Satellites connect to the **hub**, and the hub routes everything. Two clients *can*
+    No. Satellites connect to **hivemind-core**, which routes everything. Two clients *can*
     exchange end-to-end-encrypted **[INTERCOM](concepts/security.md)** messages, but those
-    are still relayed through the hub — there is no satellite-to-satellite peer link.
-    Hubs, on the other hand, can connect to *other hubs* to form a
+    are still relayed through hivemind-core — there is no satellite-to-satellite peer link.
+    hivemind-core instances, on the other hand, can connect to *other instances* to form a
     [mesh](concepts/mesh.md).
+
+---
 
 ## Setup
 
 ??? question "What's the easiest way to get started?"
     Two options:
 
-    - **Web UI:** the [Admin Panel](server/admin-panel.md) starts a hub *and* gives you a
+    - **Web UI:** the [Admin Panel](server/admin-panel.md) starts hivemind-core *and* gives you a
       browser to manage it — one command.
     - **Command line:** the [Quick Start](quickstart.md) takes you from zero to a working
-      hub + voice satellite in about ten minutes.
+      hivemind-core + voice satellite in about ten minutes.
 
     No hardware? Try the [WebSpeech browser satellite](satellites/webspeech.md).
 
-??? question "Do I need a dedicated server for the hub?"
-    No. The hub runs fine on a laptop/desktop (Linux, macOS, Windows via WSL), a Raspberry
+??? question "Do I need a dedicated machine for hivemind-core?"
+    No. hivemind-core runs fine on a laptop/desktop (Linux, macOS, Windows via WSL), a Raspberry
     Pi 4+ (good for several satellites), a cloud VM, or a [Docker container](server/docker.md).
 
 ??? question "Can I run it over the internet?"
@@ -52,6 +59,8 @@ Short answers with links to the full pages. New to the vocabulary? Keep the
     TLS). Internet-facing, put it behind a reverse proxy (Caddy, nginx, Traefik) that
     terminates real TLS, and keep a strong password + firewall. See
     [Operations](server/operations.md) and [Security](concepts/security.md).
+
+---
 
 ## Security
 
@@ -68,6 +77,8 @@ Short answers with links to the full pages. New to the vocabulary? Keep the
     polling/REST-style clients. Both carry the exact same encrypted messages. See
     [Transports](server/transports.md).
 
+---
+
 ## Satellites & devices
 
 ??? question "Which satellite should I choose?"
@@ -83,11 +94,13 @@ Short answers with links to the full pages. New to the vocabulary? Keep the
     Yes. Each connects independently with its own access key and permissions. They can share
     an OVOS session for conversational continuity.
 
+---
+
 ## Integration & development
 
 ??? question "Can I run OVOS skills?"
-    Yes — the OVOS skills hub runs the full skill stack; existing OVOS skills work as-is.
-    See [OVOS Skills Hub](server/ovos-hub.md).
+    Yes — the OVOS skills backend runs the full skill stack; existing OVOS skills work as-is.
+    See [OVOS Skills Server](server/ovos-hub.md).
 
 ??? question "How do I connect a chat platform or smart home?"
     Use a [bridge](integrations/index.md): [Home Assistant](integrations/home-assistant.md),
@@ -101,25 +114,29 @@ Short answers with links to the full pages. New to the vocabulary? Keep the
     Python) or [HiveMind-js](satellites/webspeech.md) for the browser. To implement the
     protocol from scratch, follow the [Protocol Specification](developers/protocol-spec.md).
 
+---
+
 ## Troubleshooting
 
-??? question "A satellite can't connect to the hub"
-    1. Confirm the hub is running and reachable (`ping <hub-ip>`).
+??? question "A satellite can't connect to hivemind-core"
+    1. Confirm hivemind-core is running and reachable (`ping <server-ip>`).
     2. From the satellite, test the credentials: `hivemind-client test-identity`.
     3. Check the firewall allows port 5678 (WebSocket) or 5679 (HTTP).
     4. Make sure the client is **allowed** — a brand-new client is denied every message type
        until you run `hivemind-core allow-msg ...` (see [Security](concepts/security.md#permissions)).
 
-??? question "How do I find the hub's address automatically?"
-    Run `hivemind-presence scan` on the same network (the hub announces itself when auto
+??? question "How do I find the server's address automatically?"
+    Run `hivemind-presence scan` on the same network (hivemind-core announces itself when auto
     discovery is enabled). Most satellites also auto-scan when you start them without a
     `--host`. See [Auto Discovery](concepts/discovery.md).
 
 ??? question "Audio is choppy or delayed"
     Prefer wired Ethernet or 5 GHz Wi-Fi; move wakeword/VAD onto the satellite
     ([Voice Relay](satellites/voice-relay.md) or [Voice Satellite](satellites/voice-sat.md)
-    rather than [Mic Satellite](satellites/mic-satellite.md)); and check the hub isn't
+    rather than [Mic Satellite](satellites/mic-satellite.md)); and check hivemind-core isn't
     CPU-bound.
+
+---
 
 ## Documentation
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,8 +25,8 @@
 ??? question "Which AI backend does it use?"
     HiveMind is **backend-agnostic**. By default hivemind-core runs
     [OpenVoiceOS](reference/glossary.md#ovos-voice-vocabulary) skills, but you can instead
-    point it at an LLM/chatbot ([Persona Server](server/persona-hub.md)) or an external agent
-    ([A2A Server](server/a2a-hub.md)). The choice is just *which
+    point it at an LLM/chatbot ([Persona Server](server/persona-server.md)) or an external agent
+    ([A2A Server](server/a2a-server.md)). The choice is just *which
     [agent plugin](concepts/plugins.md)* hivemind-core loads.
 
 ??? question "Do satellites talk directly to each other?"
@@ -100,7 +100,7 @@
 
 ??? question "Can I run OVOS skills?"
     Yes — the OVOS skills backend runs the full skill stack; existing OVOS skills work as-is.
-    See [OVOS Skills Server](server/ovos-hub.md).
+    See [OVOS Skills Server](server/ovos-server.md).
 
 ??? question "How do I connect a chat platform or smart home?"
     Use a [bridge](integrations/index.md): [Home Assistant](integrations/home-assistant.md),

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Choose the path that fits you:
     | Run everything from a friendly web UI | [Admin Panel](server/admin-panel.md) |
     | Pick the right satellite for my hardware | [Choosing a Satellite](satellites/index.md) |
     | Run HiveMind in Docker | [Docker Deployment](server/docker.md) |
-    | Just chat with an LLM (no skills) | [Persona Server](server/persona-hub.md) |
+    | Just chat with an LLM (no skills) | [Persona Server](server/persona-server.md) |
     | Integrate with Home Assistant | [Home Assistant](integrations/home-assistant.md) |
     | Get unstuck | [FAQ](faq.md) · [Glossary](reference/glossary.md) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,16 +3,21 @@
 
 ![HiveMind Logo](https://github.com/JarbasHiveMind/HiveMind-assets/raw/master/logo/hivemind-512.png)
 
+**HiveMind is an open-source protocol and platform** that connects lightweight **[satellite](reference/glossary.md#roles)** devices to a central AI server — **[hivemind-core](reference/glossary.md#roles)** — over the network. Satellites range from text-only CLI clients to full voice-capable devices. hivemind-core can run an [OpenVoiceOS](https://openvoiceos.github.io/community-docs) skills server or a standalone LLM/persona server.
+
+!!! abstract "In a nutshell"
+    - HiveMind moves the heavy AI work onto a central hivemind-core server so satellite devices can stay cheap and simple.
+    - Every connection is encrypted and permissioned; each client authenticates with its own access key and password.
+    - The protocol is transport- and payload-agnostic, and hivemind-core instances can chain into a mesh.
+
 !!! tip "New to HiveMind?"
     Start with the [Glossary](reference/glossary.md) — it defines every term used here
     in one page — then follow the [Quick Start](quickstart.md). You don't need to be a
     developer to run HiveMind.
 
-HiveMind is an open-source protocol and platform that connects lightweight **[satellite](reference/glossary.md#roles)** devices to a central AI **[hub](reference/glossary.md#roles)** over the network. Satellites range from text-only CLI clients to full voice-capable devices. The hub can be an [OpenVoiceOS](https://openvoiceos.github.io/community-docs) skills server or a standalone LLM/persona server.
-
 ```
 [Voice Satellite] ──┐
-[Mic Satellite]  ───┤──→ [HiveMind Hub] ──→ skills / LLM / intents
+[Mic Satellite]  ───┤──→ [hivemind-core] ──→ skills / LLM / intents
 [CLI Client]     ───┤
 [Browser Tab]    ───┘
 ```
@@ -23,7 +28,7 @@ HiveMind is an open-source protocol and platform that connects lightweight **[sa
 - **Payload-agnostic** — OVOS messages by default; agent protocol plugins support other backends
 - **Encrypted by default** — authenticated encryption (AES-256-GCM or ChaCha20-Poly1305) with per-client access keys and a PBKDF2 password handshake
 - **Fine-grained ACL** — per-client allowlists for message types, skills, and intents; fail-closed
-- **Mesh-capable** — hubs connect to other hubs; ESCALATE goes up the chain, BROADCAST goes down
+- **Mesh-capable** — hivemind-core instances connect to other instances; ESCALATE goes up the chain, BROADCAST goes down
 
 ---
 
@@ -39,24 +44,24 @@ Choose the path that fits you:
     | I want to… | Go to |
     |---|---|
     | Understand what HiveMind is, in plain terms | [About](about.md) |
-    | Set up a hub and connect my first satellite | [Quick Start](quickstart.md) |
+    | Set up hivemind-core and connect my first satellite | [Quick Start](quickstart.md) |
     | Run everything from a friendly web UI | [Admin Panel](server/admin-panel.md) |
     | Pick the right satellite for my hardware | [Choosing a Satellite](satellites/index.md) |
     | Run HiveMind in Docker | [Docker Deployment](server/docker.md) |
-    | Just chat with an LLM (no skills) | [Persona Hub](server/persona-hub.md) |
+    | Just chat with an LLM (no skills) | [Persona Server](server/persona-hub.md) |
     | Integrate with Home Assistant | [Home Assistant](integrations/home-assistant.md) |
     | Get unstuck | [FAQ](faq.md) · [Glossary](reference/glossary.md) |
 
 === "I want to *build* on HiveMind"
 
-    Connect from code, implement the protocol elsewhere, or extend a hub.
+    Connect from code, implement the protocol elsewhere, or extend hivemind-core.
 
     | I want to… | Go to |
     |---|---|
     | Connect to a hive from Python | [Client Library](developers/client-library.md) |
     | Implement HiveMind in another language | [Protocol Specification](developers/protocol-spec.md) |
     | Add a transport, backend, database, or policy | [Writing Plugins](developers/writing-plugins.md) |
-    | Test a satellite, hub, or whole mesh | [Testing](developers/testing.md) |
+    | Test a satellite, hivemind-core, or whole mesh | [Testing](developers/testing.md) |
     | Look up a CLI flag, config key, or message type | [Reference](reference/index.md) |
 
 ---
@@ -69,4 +74,4 @@ Choose the path that fits you:
 
 ---
 
-**Next:** [Quick Start](quickstart.md) — set up a hub and connect your first satellite.
+**Next:** [Quick Start](quickstart.md) — set up hivemind-core and connect your first satellite.

--- a/docs/integrations/deltachat.md
+++ b/docs/integrations/deltachat.md
@@ -1,10 +1,15 @@
 # DeltaChat Bridge
 
-[HiveMind-deltachat-bridge](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge)
-connects a [DeltaChat](https://delta.chat/) account to a HiveMind hub. Anyone who
-emails the bot account gets their message forwarded to the hub as an
-[utterance](../reference/glossary.md#utterance); the hub's spoken reply comes back as
+**[HiveMind-deltachat-bridge](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge)
+connects a [DeltaChat](https://delta.chat/) account to a HiveMind.** Anyone who
+emails the bot account gets their message forwarded to `hivemind-core` as an
+[utterance](../reference/glossary.md#utterance); the spoken reply comes back as
 a chat message in the same conversation.
+
+!!! abstract "In a nutshell"
+    - Runs as the `hm-deltachat-bridge` console command, relaying between an email account and `hivemind-core`.
+    - Needs two credential sets: an email account for DeltaChat and the stored HiveMind node identity.
+    - The bridge client needs at minimum `allow-msg "speak"`.
 
 DeltaChat is an end-to-end encrypted messenger that rides on ordinary **email** — any
 mailbox works as its transport, so there is no separate chat server to run. To people
@@ -13,7 +18,9 @@ chatting with it, the bot looks like a normal DeltaChat contact.
 !!! tip "Beginner's mental model"
     You give the bridge two sets of credentials: an **email account** (so it can send
     and receive DeltaChat messages) and your **HiveMind identity** (so it can talk to
-    the hub). It sits in the middle and relays between the two.
+    `hivemind-core`). It sits in the middle and relays between the two.
+
+---
 
 ## Install
 
@@ -22,6 +29,8 @@ pip install HiveMind-deltachat-bridge
 ```
 
 This installs the `hm-deltachat-bridge` console command.
+
+---
 
 ## Set your HiveMind identity
 
@@ -35,6 +44,8 @@ hivemind-client set-identity
 
 If no identity is stored and you don't pass the connection flags manually, the bridge
 exits with `NodeIdentity not set`.
+
+---
 
 ## Usage
 
@@ -68,12 +79,16 @@ hm-deltachat-bridge \
     command blocks until it receives an exit signal (Ctrl-C), then cleanly stops the
     bridge node.
 
+---
+
 ## How it works
 
 The bridge runs as a HiveMind client. An incoming DeltaChat message becomes a
 `recognizer_loop:utterance` [BUS message](../reference/glossary.md#bus-message) sent
-to the hub. The hub's `speak` response is delivered back to the originating DeltaChat
+to `hivemind-core`. The `speak` response is delivered back to the originating DeltaChat
 conversation.
+
+---
 
 ## Permissions
 
@@ -84,6 +99,8 @@ hivemind-core allow-msg "speak" <id>
 ```
 
 Grant additional message types if your use case needs them.
+
+---
 
 ## Source
 

--- a/docs/integrations/hackchat.md
+++ b/docs/integrations/hackchat.md
@@ -1,19 +1,26 @@
 # HackChat
 
-[HiveMind-HackChatBridge](https://github.com/JarbasHiveMind/HiveMind-HackChatBridge)
-relays a [hack.chat](https://hack.chat/) channel to and from a HiveMind hub. Whatever
-is said in the channel is forwarded to the hub as an
-[utterance](../reference/glossary.md#utterance), and the hub's spoken reply is posted
+**[HiveMind-HackChatBridge](https://github.com/JarbasHiveMind/HiveMind-HackChatBridge)
+relays a [hack.chat](https://hack.chat/) channel to and from a HiveMind.** Whatever
+is said in the channel is forwarded to `hivemind-core` as an
+[utterance](../reference/glossary.md#utterance), and the spoken reply is posted
 back into the same channel.
+
+!!! abstract "In a nutshell"
+    - Runs as the `hivemind-hackchat-bridge` console command; pick any channel name and a bot nickname.
+    - Needs no platform credentials — only your HiveMind identity (stored, or passed via `--access-key` / `--password` / `--host`).
+    - The bridge client needs at minimum `allow-msg "speak"`.
 
 hack.chat is a minimal, **anonymous** public chat — you join a channel just by naming
 it, with no sign-up. That makes this the simplest bridge to try: there are **no
 platform credentials to obtain**, only your HiveMind identity.
 
 !!! tip "Beginner's mental model"
-    Pick any channel name, pick a nickname for the bot, point it at your hub. The bot
+    Pick any channel name, pick a nickname for the bot, point it at `hivemind-core`. The bot
     joins that hack.chat channel and relays messages to your hive. No account, no
     token, no API key on the chat side.
+
+---
 
 ## Install
 
@@ -23,9 +30,11 @@ pip install HiveMind-HackChatBridge
 
 This installs the `hivemind-hackchat-bridge` console command.
 
+---
+
 ## Set your HiveMind identity
 
-The bridge connects to the hub with your stored
+The bridge connects to `hivemind-core` with your stored
 [node identity](../reference/glossary.md#node). Set it once on the machine that runs
 the bridge:
 
@@ -34,6 +43,8 @@ hivemind-client set-identity
 ```
 
 You can also pass `--access-key`, `--password`, and `--host` directly instead.
+
+---
 
 ## Usage
 
@@ -68,13 +79,17 @@ channel, and the bot's replies appear inline.
 ??? note "Advanced: anonymity and addressing"
     Because hack.chat has no accounts, every participant is identified only by the
     nickname they choose for that session. The bridge forwards each message with the
-    sender's nickname so the hub can address its reply back to the right person.
+    sender's nickname so `hivemind-core` can address its reply back to the right person.
+
+---
 
 ## How it works
 
 The bridge runs as a HiveMind client. Each channel message becomes a
 `recognizer_loop:utterance` [BUS message](../reference/glossary.md#bus-message) sent
-to the hub; the hub's `speak` response is posted back into the channel.
+to `hivemind-core`; the `speak` response is posted back into the channel.
+
+---
 
 ## Permissions
 
@@ -83,6 +98,8 @@ The bridge client needs at minimum:
 ```bash
 hivemind-core allow-msg "speak" <id>
 ```
+
+---
 
 ## Source
 

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -1,8 +1,13 @@
 # Home Assistant Integration
 
-[hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant) is a manual-install Home Assistant custom integration that connects Home Assistant to an OVOS instance via HiveMind.
+**[hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant) is a manual-install Home Assistant custom integration** that connects Home Assistant to an OVOS instance via HiveMind. It exposes the OVOS device as a Home Assistant entity with controls for audio playback, volume, microphone state, system power, and status sensors.
 
-It exposes the OVOS device as a Home Assistant entity with controls for audio playback, volume, microphone state, system power, and status sensors.
+!!! abstract "In a nutshell"
+    - A `custom_components/hivemind` integration installed by hand, then added via **Settings → Devices & Services**.
+    - Its HiveMind client must have **admin privileges** and explicit access to a broad set of bus message types.
+    - Grant those message types with `hivemind-core allow-msg` and `hivemind-core make-admin`, passing the node ID positionally.
+
+---
 
 ## Installation
 
@@ -16,6 +21,8 @@ cp -r custom_components/hivemind /config/custom_components/
 2. Restart Home Assistant.
 
 3. Add the integration via **Settings → Devices & Services → Add Integration → HiveMind**.
+
+---
 
 ## Required permissions
 
@@ -155,11 +162,15 @@ hivemind-core allow-msg "mycroft.volume.get" <id>
 hivemind-core make-admin <id>
 ```
 
+---
+
 ## Related projects
 
 - [Media Player](media-player.md) — turn any device into a standalone HiveMind OCP player
 - [ovos-skill-music-assistant](https://github.com/HiveMindInsiders/ovos-skill-music-assistant) — OVOS skill for Music Assistant media search
 - [ovos-media-plugin-mass](https://github.com/HiveMindInsiders/ovos-media-plugin-mass) — OVOS plugin to control Music Assistant players
+
+---
 
 ## Source
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -3,13 +3,15 @@
 A **bridge** connects HiveMind to a chat network or smart-home platform, so people can
 talk to your hive from apps they already use — Matrix, a Twitch stream, Home Assistant,
 and more. Under the hood every bridge is just another [satellite](../reference/glossary.md#roles):
-it holds an access key and relays messages to the hub.
+it holds an access key and relays messages to `hivemind-core`.
 
 !!! note "Bridges are satellites too"
     Anything in this section connects the same way the [Quick Start](../quickstart.md)
     satellite did — register it with `hivemind-core add-client`, give it the access key
-    and password, point it at the hub. The integration-specific part is only *which
+    and password, point it at `hivemind-core`. The integration-specific part is only *which
     outside service* it relays to.
+
+---
 
 ## What's in this section
 

--- a/docs/integrations/matrix.md
+++ b/docs/integrations/matrix.md
@@ -1,19 +1,28 @@
 # Matrix Bridge
 
-[HiveMind-matrix-bridge](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge) connects a [Matrix](https://matrix.org/) chat room to a HiveMind hub. Messages posted in the room are forwarded to the hub as utterances; responses come back as messages in the room.
+**[HiveMind-matrix-bridge](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge) connects a [Matrix](https://matrix.org/) chat room to a HiveMind.** Messages posted in the room are forwarded to `hivemind-core` as utterances; responses come back as messages in the room.
+
+!!! abstract "In a nutshell"
+    - Logs into Matrix as a bot with an access token and relays room messages to `hivemind-core`.
+    - HiveMind credentials come from the stored node identity (`hivemind-client set-identity`); the `run` command takes no HiveMind flags.
+    - The bridge client needs at minimum `allow-msg "speak"`.
 
 Matrix is a federated, end-to-end-encrypted chat protocol. You register a bot account at any Matrix provider and the bridge logs in as that bot.
 
 !!! tip "Beginner's mental model"
     The bridge logs into Matrix as a bot using an access token, joins a room, and
-    relays whatever is said there to your hub. Its HiveMind credentials come from the
+    relays whatever is said there to `hivemind-core`. Its HiveMind credentials come from the
     [identity](../reference/glossary.md#node) you set once with `hivemind-client set-identity`.
+
+---
 
 ## Install
 
 ```bash
 pip install HiveMind-matrix-bridge
 ```
+
+---
 
 ## Usage
 
@@ -43,9 +52,13 @@ HiveMind-matrix run \
   --room "#hivemind-bots:matrix.org"
 ```
 
+---
+
 ## How it works
 
-The bridge runs as a HiveMind client. Each Matrix message from a room member is wrapped in a `recognizer_loop:utterance` OVOS message and sent to the hub via `BUS`. The hub processes the utterance and returns a `speak` response; the bridge posts the spoken text back to the Matrix room.
+The bridge runs as a HiveMind client. Each Matrix message from a room member is wrapped in a `recognizer_loop:utterance` OVOS message and sent to `hivemind-core` via `BUS`. `hivemind-core` processes the utterance and returns a `speak` response; the bridge posts the spoken text back to the Matrix room.
+
+---
 
 ## Permissions required
 
@@ -56,6 +69,8 @@ hivemind-core allow-msg "speak" <id>
 ```
 
 Add further permissions if your use case requires access to specific skills or message types.
+
+---
 
 ## Source
 

--- a/docs/integrations/mattermost.md
+++ b/docs/integrations/mattermost.md
@@ -1,14 +1,21 @@
 # Mattermost Bridge
 
-[HiveMind-mattermost-bridge](https://github.com/JarbasHiveMind/HiveMind_mattermost_bridge)
-connects a [Mattermost](https://mattermost.com/) team server to a HiveMind hub. People
+**[HiveMind-mattermost-bridge](https://github.com/JarbasHiveMind/HiveMind_mattermost_bridge)
+connects a [Mattermost](https://mattermost.com/) team server to a HiveMind.** People
 talk to the assistant through direct messages or by mentioning the bot in a channel;
-the hub's reply is posted back into the same conversation.
+the reply from `hivemind-core` is posted back into the same conversation.
+
+!!! abstract "In a nutshell"
+    - Runs as the `hivemind-mattermost-bridge` console command, logging into Mattermost as a bot user account (email/login and password).
+    - HiveMind connection details default to the stored node identity; pass the Mattermost flags each run.
+    - The bridge client needs at minimum `allow-msg "speak"`.
 
 !!! tip "Beginner's mental model"
     The bridge logs into Mattermost as a normal **bot user account** (an email/login
-    and password, not an API token), and connects to your hub using your stored
+    and password, not an API token), and connects to `hivemind-core` using your stored
     HiveMind identity. It relays messages between the two.
+
+---
 
 ## Install
 
@@ -17,6 +24,8 @@ pip install HiveMind-mattermost-bridge
 ```
 
 This installs the `hivemind-mattermost-bridge` console command.
+
+---
 
 ## Set your HiveMind identity
 
@@ -27,6 +36,8 @@ machine that runs the bridge, then you only need to pass the Mattermost flags:
 ```bash
 hivemind-client set-identity
 ```
+
+---
 
 ## Usage
 
@@ -87,12 +98,16 @@ Bot: @user , The weather is...
     webhook or listener port is needed on the Mattermost side. The Mattermost listen
     loop runs in a daemon thread alongside the HiveMind bus client.
 
+---
+
 ## How it works
 
 The bridge runs as a HiveMind client. A direct message or mention becomes a
 `recognizer_loop:utterance` [BUS message](../reference/glossary.md#bus-message)
-tagged with the sender and channel. The hub's `speak` response is posted back to that
+tagged with the sender and channel. The `speak` response from `hivemind-core` is posted back to that
 channel, addressed to the sender as `@user , <answer>`.
+
+---
 
 ## Permissions
 
@@ -101,6 +116,8 @@ The bridge client needs at minimum:
 ```bash
 hivemind-core allow-msg "speak" <id>
 ```
+
+---
 
 ## Source
 

--- a/docs/integrations/media-player.md
+++ b/docs/integrations/media-player.md
@@ -1,10 +1,15 @@
 # Media Player
 
-[hivemind-media-player](https://github.com/JarbasHiveMind/hivemind-media-player) turns
-a headless device into a **network-controlled media player** driven over HiveMind.
+**[hivemind-media-player](https://github.com/JarbasHiveMind/hivemind-media-player) turns
+a headless device into a network-controlled media player driven over HiveMind.**
 Remote controllers send standard [OCP](../reference/glossary.md#ocp-ovos-common-play)
 playback commands across the encrypted HiveMind connection, and this device plays the
 audio locally.
+
+!!! abstract "In a nutshell"
+    - The `hivemind-player-protocol` package registers a `hivemind.agent.protocol` entry point exposing `HiveMindPlayerProtocol` — an agent plugin, not an OVOS skill.
+    - For devices with no voice assistant of their own; it plays OCP/audio bus messages through a local `ovos-audio` stack.
+    - Complements the [Home Assistant integration](home-assistant.md): player devices appear as Home Assistant media players.
 
 !!! tip "Beginner's mental model"
     Turn a Raspberry Pi or a spare speaker into a player you control from your hive.
@@ -16,6 +21,8 @@ networked speaker, for example. It complements the
 [Home Assistant integration](home-assistant.md): with both installed, your HiveMind
 player devices show up as media players in Home Assistant (and Music Assistant can
 browse and play music to them).
+
+---
 
 ## How it fits in
 
@@ -32,6 +39,8 @@ available) and routes incoming playback messages to it.
     `hivemind-core` and play them through the local audio stack. Running it as an agent
     protocol inside `hivemind-core` (rather than a skill inside `ovos-core`) is what
     lets a device with no assistant of its own act purely as a remote player.
+
+---
 
 ## Install
 
@@ -53,6 +62,8 @@ register a client credential, and start `hivemind-core listen`. See the reposito
 README for the full step-by-step quickstart and the bundled `hivemind-player-ctl`
 control CLI.
 
+---
+
 ## Permissions
 
 The player client needs at minimum the core audio and OCP playback messages, for
@@ -71,11 +82,15 @@ hivemind-core allow-msg "ovos.common_play.previous" <id>
 The repository's permissions reference lists the full OCP, audio, and (optional) PHAL
 volume message sets.
 
+---
+
 ## Related projects
 
 - [hivemind-homeassistant](home-assistant.md) — exposes HiveMind player devices as Home Assistant media players
 - [ovos-skill-music-assistant](https://github.com/HiveMindInsiders/ovos-skill-music-assistant) — OVOS skill for Music Assistant media search
 - [ovos-media-plugin-mass](https://github.com/HiveMindInsiders/ovos-media-plugin-mass) — OVOS plugin to control Music Assistant players
+
+---
 
 ## Source
 

--- a/docs/integrations/twitch.md
+++ b/docs/integrations/twitch.md
@@ -1,15 +1,22 @@
 # Twitch Bridge
 
-[HiveMind-twitch-bridge](https://github.com/JarbasHiveMind/HiveMind-twitch-bridge)
-relays a [Twitch](https://www.twitch.tv/) channel's live chat to and from a HiveMind
-hub. A viewer who mentions the bot in chat gets their message forwarded to the hub as
-an [utterance](../reference/glossary.md#utterance); the hub's reply is posted back
+**[HiveMind-twitch-bridge](https://github.com/JarbasHiveMind/HiveMind-twitch-bridge)
+relays a [Twitch](https://www.twitch.tv/) channel's live chat to and from a
+HiveMind.** A viewer who mentions the bot in chat gets their message forwarded to `hivemind-core` as
+an [utterance](../reference/glossary.md#utterance); the reply is posted back
 into the stream chat.
+
+!!! abstract "In a nutshell"
+    - Runs as the `hivemind-twitch-bridge` console command, joining chat over IRC with a channel name and a Twitch chat OAuth token.
+    - Only messages containing a trigger tag are relayed; the tag is stripped before forwarding.
+    - HiveMind credentials are passed as flags; the bridge client needs at minimum `allow-msg "speak"`.
 
 !!! tip "Beginner's mental model"
     The bridge joins your Twitch chat as a bot (using a chat OAuth token) and connects
-    to your hub. Only messages that contain a trigger tag are relayed, so it stays
+    to `hivemind-core`. Only messages that contain a trigger tag are relayed, so it stays
     quiet until someone calls on it.
+
+---
 
 ## Install
 
@@ -19,12 +26,16 @@ pip install HiveMind-twitch-bridge
 
 This installs the `hivemind-twitch-bridge` console command.
 
+---
+
 ## Get a Twitch chat token
 
 Authentication is just the channel name plus a Twitch **chat OAuth token** (of the
 form `oauth:...`), which you can generate at
 [twitchapps.com/tmi](https://www.twitchapps.com/tmi/). No Twitch application or client
 ID is required.
+
+---
 
 ## Usage
 
@@ -79,12 +90,16 @@ Bot: @viewer , The weather in Seattle is...
     `--host` must start with `ws://` or `wss://`, otherwise the command exits with an
     error. There is no rate limiting and the reply prefix is fixed.
 
+---
+
 ## How it works
 
 The bridge reads Twitch chat over IRC. A message containing a trigger tag becomes a
 `recognizer_loop:utterance` [BUS message](../reference/glossary.md#bus-message) sent
-to the hub; the hub's `speak` response is sent back to the channel as
+to `hivemind-core`; the `speak` response is sent back to the channel as
 `@user , <answer>`.
+
+---
 
 ## Permissions
 
@@ -93,6 +108,8 @@ The bridge client needs at minimum:
 ```bash
 hivemind-core allow-msg "speak" <id>
 ```
+
+---
 
 ## Source
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,16 +1,21 @@
 # Quick Start
 
-This guide takes you from zero to a working hub with one connected satellite in under ten minutes.
+**This guide takes you from zero to a working hivemind-core server** with one connected satellite in under ten minutes.
 
-**Scope:** this guide sets up **one hub + one voice satellite on the same LAN**. To try it all on a single machine, use `--host 127.0.0.1` everywhere. Find your hub's LAN IP with `hostname -I`. Each step below is labelled **(ON THE HUB)** or **(ON THE SATELLITE)** so you know where to run it.
+!!! abstract "In a nutshell"
+    - Install `hivemind-core` on the server, register a client with `add-client`, then connect a satellite with its access key and password.
+    - The default OVOS skills backend needs `ovos-core` and `ovos-messagebus` running first; a persona backend needs neither.
+    - Success is a full round trip: wakeword → speech → the server's skill → a spoken answer on the satellite.
+
+**Scope:** this guide sets up **one hivemind-core server + one voice satellite on the same LAN**. To try it all on a single machine, use `--host 127.0.0.1` everywhere. Find your server's LAN IP with `hostname -I`. Each step below is labelled **(ON THE SERVER)** or **(ON THE SATELLITE)** so you know where to run it.
 
 New to the terms here? Keep the [Glossary](reference/glossary.md) open in another tab.
 
 ---
 
-## Step 0 — Prerequisites (ON THE HUB)
+## Step 0 — Prerequisites (ON THE SERVER)
 
-The OVOS skills hub runs your skills on top of OpenVoiceOS, so `ovos-core` and `ovos-messagebus` must be installed and running on the hub machine before HiveMind can talk to them:
+The OVOS skills backend runs your skills on top of OpenVoiceOS, so `ovos-core` and `ovos-messagebus` must be installed and running on the server machine before HiveMind can talk to them:
 
 ```bash
 pip install ovos-core ovos-messagebus
@@ -24,17 +29,19 @@ ovos-core
 
 See the [OVOS documentation](https://openvoiceos.github.io/community-docs) for a full OVOS setup.
 
-> **Want the simplest possible first run with no OVOS?** Use the [Persona hub](server/persona-hub.md) instead — it serves an LLM/chatbot via `hivemind-persona-agent-plugin` + `ovos-persona` and needs neither `ovos-core` nor `ovos-messagebus`. The HiveMind steps below are otherwise identical.
+> **Want the simplest possible first run with no OVOS?** Use the [persona backend](server/persona-hub.md) instead — it serves an LLM/chatbot via `hivemind-persona-agent-plugin` + `ovos-persona` and needs neither `ovos-core` nor `ovos-messagebus`. The HiveMind steps below are otherwise identical.
 
 ---
 
-## Step 1 — Install HiveMind Core on the hub (ON THE HUB)
+## Step 1 — Install HiveMind Core on the server (ON THE SERVER)
 
 ```bash
 pip install hivemind-core
 ```
 
-## Step 2 — Start the server (ON THE HUB)
+---
+
+## Step 2 — Start the server (ON THE SERVER)
 
 ```bash
 hivemind-core listen
@@ -45,9 +52,9 @@ The server accepts satellite connections on port 5678 (WebSocket) and port 5679 
 ### What you are building
 
 ```
-            ON THE HUB                              ON THE SATELLITE
+            ON THE SERVER                              ON THE SATELLITE
  ┌─────────────────────────────┐           ┌──────────────────────────┐
- │        HiveMind Hub         │  LAN      │     Voice Satellite      │
+ │        hivemind-core        │  LAN      │     Voice Satellite      │
  │  (hivemind-core listen)     │◄─ ws ────►│  (hivemind-voice-sat)    │
  │                             │  :5678    │                          │
  │  • OVOS skills              │           │  • microphone            │
@@ -57,11 +64,13 @@ The server accepts satellite connections on port 5678 (WebSocket) and port 5679 
  └─────────────────────────────┘           └──────────────────────────┘
 ```
 
-The voice satellite captures audio and does its own speech-to-text, then sends the text utterance to the hub; the hub runs the skill and sends a spoken reply back. (Other satellite types push more of that work onto the hub — see [Choosing a Satellite](satellites/index.md).)
+The voice satellite captures audio and does its own speech-to-text, then sends the text utterance to hivemind-core; hivemind-core runs the skill and sends a spoken reply back. (Other satellite types push more of that work onto hivemind-core — see [Choosing a Satellite](satellites/index.md).)
 
-## Step 3 — Register credentials for a satellite (ON THE HUB)
+---
 
-On the hub machine, add a client entry:
+## Step 3 — Register credentials for a satellite (ON THE SERVER)
+
+On the server machine, add a client entry:
 
 ```bash
 hivemind-core add-client --name "my-satellite"
@@ -80,9 +89,11 @@ Encryption Key: 4185240103de0770
 WARNING: Encryption Key is deprecated, only use if your client does not support password
 ```
 
-Note the **Access Key** and **Password** — you will need them on the satellite. In the steps below, replace `<ACCESS_KEY>` and `<PASSWORD>` with the values printed by `add-client`, and `<HUB_IP>` with the hub's LAN IP from `hostname -I` (or `127.0.0.1` on a single machine).
+Note the **Access Key** and **Password** — you will need them on the satellite. In the steps below, replace `<ACCESS_KEY>` and `<PASSWORD>` with the values printed by `add-client`, and `<SERVER_IP>` with the server's LAN IP from `hostname -I` (or `127.0.0.1` on a single machine).
 
 > Use `hivemind-core add-client --help` to supply your own key and password instead of generated ones. Other options: `--name`, `--access-key`, `--password`, `--crypto-key`, `--admin`, `--metadata`.
+
+---
 
 ## Step 4 — Install and configure the satellite (ON THE SATELLITE)
 
@@ -103,12 +114,14 @@ Write the identity file:
 hivemind-client set-identity \
   --key <ACCESS_KEY> \
   --password <PASSWORD> \
-  --host <HUB_IP> \
+  --host <SERVER_IP> \
   --port 5678 \
   --siteid living-room
 ```
 
 This writes `~/.config/hivemind/_identity.json`. All satellite commands read this file by default.
+
+---
 
 ## Step 5 — Test the connection (ON THE SATELLITE)
 
@@ -122,6 +135,8 @@ Expected output:
 == Identity successfully connected to HiveMind!
 ```
 
+---
+
 ## Step 6 — Start the satellite (ON THE SATELLITE)
 
 ```bash
@@ -131,25 +146,27 @@ hivemind-voice-sat
 Or pass credentials directly instead of relying on the identity file:
 
 ```bash
-hivemind-voice-sat --host <HUB_IP> --key <ACCESS_KEY> --password <PASSWORD>
+hivemind-voice-sat --host <SERVER_IP> --key <ACCESS_KEY> --password <PASSWORD>
 ```
 
 `hivemind-voice-sat` also accepts `--port`, `--siteid`, and `--selfsigned` (accept self-signed certificates).
 
+---
+
 ## Step 7 — Talk to it (ON THE SATELLITE)
 
-With the hub running (Steps 0–2) and the satellite running (Step 6), speak to the satellite:
+With hivemind-core running (Steps 0–2) and the satellite running (Step 6), speak to the satellite:
 
 > **"hey mycroft, what time is it?"**
 
-**Success looks like:** the satellite plays a spoken reply (the current time). That round trip — wakeword → your speech → the hub's skill → a spoken answer — means the whole path works.
+**Success looks like:** the satellite plays a spoken reply (the current time). That round trip — wakeword → your speech → the server's skill → a spoken answer — means the whole path works.
 
 **No reply?**
 
 - Check the satellite's terminal logs for connection or audio errors.
-- Re-run `hivemind-client test-identity` on the satellite to confirm it still reaches the hub.
+- Re-run `hivemind-client test-identity` on the satellite to confirm it still reaches the server.
 - Remember that `hivemind-voice-sat`'s **default STT and TTS are remote services** hosted at `*.openvoiceos.org`, so the satellite needs internet access on first run. To go fully local, install and configure local STT/TTS plugins on the satellite — see [Voice Satellite](satellites/voice-sat.md).
-- Confirm `ovos-core` and `ovos-messagebus` are still running on the hub (Step 0).
+- Confirm `ovos-core` and `ovos-messagebus` are still running on the server (Step 0).
 
 ---
 
@@ -177,9 +194,9 @@ For the full CLI reference see [CLI Reference](reference/cli.md) and [Permission
 
 - [Choosing a Satellite](satellites/index.md) — compare all satellite options
 - [Permissions](concepts/security.md#permissions) — restrict what each client can do
-- [Auto Discovery](concepts/discovery.md) — find the hub automatically over the local network
-- [Docker Deployment](server/docker.md) — run the hub in a container
-- [Nested Hives](concepts/mesh.md#nested-hives) — connect hubs to other hubs
+- [Auto Discovery](concepts/discovery.md) — find hivemind-core automatically over the local network
+- [Docker Deployment](server/docker.md) — run hivemind-core in a container
+- [Nested Hives](concepts/mesh.md#nested-hives) — connect hivemind-core instances to other instances
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,7 @@ ovos-core
 
 See the [OVOS documentation](https://openvoiceos.github.io/community-docs) for a full OVOS setup.
 
-> **Want the simplest possible first run with no OVOS?** Use the [persona backend](server/persona-hub.md) instead — it serves an LLM/chatbot via `hivemind-persona-agent-plugin` + `ovos-persona` and needs neither `ovos-core` nor `ovos-messagebus`. The HiveMind steps below are otherwise identical.
+> **Want the simplest possible first run with no OVOS?** Use the [persona backend](server/persona-server.md) instead — it serves an LLM/chatbot via `hivemind-persona-agent-plugin` + `ovos-persona` and needs neither `ovos-core` nor `ovos-messagebus`. The HiveMind steps below are otherwise identical.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,15 @@
 # CLI Reference
 
+**Every command and flag across the three HiveMind command-line tools**, grouped by the package that provides them.
+
+!!! abstract "In a nutshell"
+    - `hivemind-core` — server-side management: client credentials, permissions, policy, and database.
+    - `hivemind-client` — satellite-side: identity, terminal, and message injection (`escalate`, `propagate`, `ping`).
+    - `hivemind-presence` — local-network discovery: `announce` and `scan`.
+    - `NODE_ID`, `MSG_TYPE`, `SKILL_ID`, and `INTENT_ID` are positional arguments; omit `NODE_ID` to pick a client interactively.
+
+---
+
 ## hivemind-core
 
 Server-side management commands for `hivemind-core`.
@@ -218,7 +228,7 @@ Commands:
   terminal           Interactive CLI: inject utterances and print speech
   test-identity      Test connection using the identity file
   reset-pgp          Recreate the RSA key pair for inter-node communication
-  send-mycroft       Send a raw OVOS message to the hub
+  send-mycroft       Send a raw OVOS message to hivemind-core
   escalate           Send an OVOS message wrapped in ESCALATE
   propagate          Send an OVOS message wrapped in PROPAGATE
   ping               Flood-ping the mesh and print the responding topology
@@ -232,8 +242,8 @@ Usage: hivemind-client set-identity [OPTIONS]
 Options:
   --key TEXT       Access key
   --password TEXT  Password
-  --host TEXT      Hub host (ws:// or wss://)
-  --port INTEGER   Hub port (default: 5678)
+  --host TEXT      Server host (ws:// or wss://)
+  --port INTEGER   Server port (default: 5678)
   --siteid TEXT    Site identifier for context routing
 ```
 
@@ -252,7 +262,7 @@ Options:
   --siteid TEXT    Site identifier
 ```
 
-Interactive CLI: type utterances to inject and the hub's speech is printed back.
+Interactive CLI: type utterances to inject and hivemind-core's speech is printed back.
 
 ### send-mycroft
 
@@ -264,7 +274,7 @@ Options:
   --payload TEXT   OVOS message data (JSON string)
   --key TEXT       Access key
   --password TEXT  Password
-  --host TEXT      Hub host
+  --host TEXT      Server host
   --port INTEGER   Port (default: 5678)
   --siteid TEXT    Site identifier
 ```
@@ -279,7 +289,7 @@ Options:
   --payload TEXT   OVOS message data (JSON string)
   --key TEXT       Access key (default: from identity file)
   --password TEXT  Password (default: from identity file)
-  --host TEXT      Hub host (default: from identity file)
+  --host TEXT      Server host (default: from identity file)
   --port INTEGER   Port (default: 5678)
   --siteid TEXT    Site identifier (default: from identity file)
 ```
@@ -296,7 +306,7 @@ Options:
   --payload TEXT   OVOS message data (JSON string)
   --key TEXT       Access key (default: from identity file)
   --password TEXT  Password (default: from identity file)
-  --host TEXT      Hub host (default: from identity file)
+  --host TEXT      Server host (default: from identity file)
   --port INTEGER   Port (default: 5678)
   --siteid TEXT    Site identifier (default: from identity file)
 ```
@@ -322,7 +332,7 @@ Flood-pings the mesh and prints the peers that respond.
 
 ### reset-pgp
 
-Recreates the private RSA key used for inter-node communication. (The command name is `reset-pgp` for historical reasons, but it generates an RSA key pair.)
+Recreates the private RSA key used for inter-node communication. Despite the name, it generates an RSA key pair.
 
 ---
 
@@ -362,6 +372,8 @@ Options:
 ---
 
 **Next:** [Configuration Reference](config.md) · [Plugin Architecture](../concepts/plugins.md)
+
+---
 
 ## Source
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,5 +1,15 @@
 # Configuration Reference
 
+**The complete `server.json` schema with every default value**, plus the satellite identity file and the default ports.
+
+!!! abstract "In a nutshell"
+    - `hivemind-core` reads `~/.config/hivemind-core/server.json` at startup; `hivemind-core listen` takes no flags, so all settings live in this file.
+    - Configurable blocks: `binarize`, `allowed_encodings`/`allowed_ciphers`, `agent_protocol`, `binary_protocol`, `network_protocol`, `policy.chain`, and `database`.
+    - The database backend and TLS certificates are auto-selected on first run.
+    - Satellites store credentials in `~/.config/hivemind/_identity.json`, written by `hivemind-client set-identity`.
+
+---
+
 ## server.json
 
 `hivemind-core` reads `~/.config/hivemind-core/server.json` at startup. `hivemind-core listen` takes no command-line flags; edit this file to change any setting.
@@ -104,7 +114,7 @@ Multiple network protocol plugins can be active simultaneously. Each key is the 
 An MQTT transport is available as an alpha: package `hivemind-mqtt-protocol`,
 plugin name `hivemind-mqtt-plugin`, broker port 1883 (config keys `broker_host`,
 `broker_port`, `broker_username`, `broker_password`, `tls`, `topic_prefix`, `qos`,
-`idle_timeout`). It currently provides the hub-side listener only. An experimental
+`idle_timeout`). It provides the server-side listener only. An experimental
 Usenet wormhole transport (`hivemind-usenet`, plugin `hivemind-usenet-wormhole`)
 also exists but is unpublished.
 
@@ -143,10 +153,10 @@ Per-plugin settings are nested under the plugin name key. See [Database Backends
 
 | Field | Description |
 |---|---|
-| `access_key` | Access credential assigned by the hub |
+| `access_key` | Access credential assigned by hivemind-core |
 | `password` | Used for PBKDF2 key derivation |
-| `default_master` | Hub host address (ws:// or wss://) |
-| `default_port` | Hub port (default: 5678) |
+| `default_master` | hivemind-core host address (ws:// or wss://) |
+| `default_port` | hivemind-core port (default: 5678) |
 | `site_id` | Location identifier injected into OVOS context |
 | `public_key` | RSA public key string |
 | `secret_key` | Path to the RSA private key (PEM) file |
@@ -164,6 +174,8 @@ Per-plugin settings are nested under the plugin name key. See [Database Backends
 ---
 
 **Next:** [CLI Reference](cli.md) · [Security & Permissions](../concepts/security.md)
+
+---
 
 ## Source
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -14,7 +14,7 @@
 | Term | Definition |
 |---|---|
 | <span id="node"></span>**Node** | Any device or process that participates in a HiveMind network. |
-| **hivemind-core** | A node that accepts connections, authenticates clients, isolates sessions, and authorizes individual messages. Runs the AI workload (skills, LLM, or audio processing) on behalf of its satellites. See [OVOS Skills backend](../server/ovos-hub.md) and [Persona backend](../server/persona-hub.md). |
+| **hivemind-core** | A node that accepts connections, authenticates clients, isolates sessions, and authorizes individual messages. Runs the AI workload (skills, LLM, or audio processing) on behalf of its satellites. See [OVOS Skills backend](../server/ovos-server.md) and [Persona backend](../server/persona-server.md). |
 | **Satellite** | A user-facing node that connects to hivemind-core but does not accept connections of its own. Ranges from text-only ([CLI](../satellites/cli.md)) to a full local voice stack ([voice satellite](../satellites/voice-sat.md)). See [Choosing a Satellite](../satellites/index.md). |
 | **Mind** | Protocol term for a node that listens for connections and understands natural-language commands — i.e. hivemind-core. A Mind authenticates other nodes, isolates their connections, and authorizes each message. |
 | **Master** | The node at the top of a hive that receives connections but does not itself connect upward as a client. |
@@ -98,7 +98,7 @@ Terms a HiveMind user runs into that come from the OVOS voice stack hivemind-cor
 | **STT (Speech-to-Text)** | Transcribes audio into text. |
 | **TTS (Text-to-Speech)** | Synthesizes spoken audio from text. |
 | **Solver** | An `ovos-persona` plugin that answers a query (e.g. an LLM backend); personas chain solvers together. |
-| **Persona** | An `ovos-persona` config — a named chain of solvers — that a [Persona backend](../server/persona-hub.md) serves instead of full skills. |
+| **Persona** | An `ovos-persona` config — a named chain of solvers — that a [Persona backend](../server/persona-server.md) serves instead of full skills. |
 | <span id="ocp-ovos-common-play"></span>**OCP (OVOS Common Play)** | The OVOS media/audio playback framework. |
 | **PHAL** | OVOS's Platform Hardware Abstraction Layer — plugins for volume, system control, and similar; relevant to the Home Assistant integration's permission list. |
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,81 +1,95 @@
 # Glossary
 
-Terms used throughout the HiveMind documentation. The user-facing guides favour
-**hub** and **satellite**; the protocol and mesh references also use the
-lower-level vocabulary (**node**, **Mind**, **master**/**slave**) — both describe
-the same network.
+**Plain-language definitions of every term used throughout the HiveMind documentation.** The user-facing guides favour **hivemind-core** and **satellite**; the protocol and mesh references also use the lower-level vocabulary (**node**, **Mind**, **master**/**slave**) — both describe the same network.
+
+!!! abstract "In a nutshell"
+    - Terms are grouped into roles, network structure, protocol, credentials & access control, discovery, and OVOS voice vocabulary.
+    - **hivemind-core** and **satellite** are the everyday names; **Mind**, **master**, and **slave** are the equivalent protocol-level terms.
+    - Keep this page open in a second tab while reading the rest of the manual.
+
+---
 
 ## Roles
 
 | Term | Definition |
 |---|---|
 | <span id="node"></span>**Node** | Any device or process that participates in a HiveMind network. |
-| **Hub** | A node that accepts connections, authenticates clients, isolates sessions, and authorizes individual messages. Runs the AI workload (skills, LLM, or audio processing) on behalf of its satellites. See [OVOS Skills Hub](../server/ovos-hub.md) and [Persona Hub](../server/persona-hub.md). |
-| **Satellite** | A user-facing node that connects to a hub but does not accept connections of its own. Ranges from text-only ([CLI](../satellites/cli.md)) to a full local voice stack ([voice satellite](../satellites/voice-sat.md)). See [Choosing a Satellite](../satellites/index.md). |
-| **Mind** | Protocol term for a node that listens for connections and understands natural-language commands — i.e. a hub. A Mind authenticates other nodes, isolates their connections, and authorizes each message. |
+| **hivemind-core** | A node that accepts connections, authenticates clients, isolates sessions, and authorizes individual messages. Runs the AI workload (skills, LLM, or audio processing) on behalf of its satellites. See [OVOS Skills backend](../server/ovos-hub.md) and [Persona backend](../server/persona-hub.md). |
+| **Satellite** | A user-facing node that connects to hivemind-core but does not accept connections of its own. Ranges from text-only ([CLI](../satellites/cli.md)) to a full local voice stack ([voice satellite](../satellites/voice-sat.md)). See [Choosing a Satellite](../satellites/index.md). |
+| **Mind** | Protocol term for a node that listens for connections and understands natural-language commands — i.e. hivemind-core. A Mind authenticates other nodes, isolates their connections, and authorizes each message. |
 | **Master** | The node at the top of a hive that receives connections but does not itself connect upward as a client. |
-| **Slave** | A hub that connects to another hub as a client and accepts bus messages from it; this is how [nested hives](../concepts/mesh.md#nested-hives) are formed. A satellite differs from a slave in that it is not itself a hub. |
-| **Bridge** | A node that links an external service (Matrix, Mattermost, DeltaChat, Twitch, …) to a hub, relaying messages in both directions. See [Integrations](../integrations/matrix.md). |
-| **Relay** | A satellite that streams audio to the hub for STT/TTS while keeping wakeword detection local. See [Voice Relay](../satellites/voice-relay.md). |
+| **Slave** | A hivemind-core instance that connects to another hivemind-core instance as a client and accepts bus messages from it; this is how [nested hives](../concepts/mesh.md#nested-hives) are formed. A satellite differs from a slave in that it is not itself a hivemind-core instance. |
+| **Bridge** | A node that links an external service (Matrix, Mattermost, DeltaChat, Twitch, …) to hivemind-core, relaying messages in both directions. See [Integrations](../integrations/matrix.md). |
+| **Relay** | A satellite that streams audio to hivemind-core for STT/TTS while keeping wakeword detection local. See [Voice Relay](../satellites/voice-relay.md). |
+
+---
 
 ## Network structure
 
 | Term | Definition |
 |---|---|
-| **Hive** | A collection of interconnected nodes — one hub and the satellites (and sub-hubs) attached to it. |
-| **Nested hive** | A hub that is also a client of a parent hub, so hives stack into a hierarchy. `ESCALATE` travels up the chain, `BROADCAST` travels down. See [Mesh & Hub Topology](../concepts/mesh.md). |
+| **Hive** | A collection of interconnected nodes — one hivemind-core instance and the satellites (and nested instances) attached to it. |
+| **Nested hive** | A hivemind-core instance that is also a client of a parent instance, so hives stack into a hierarchy. `ESCALATE` travels up the chain, `BROADCAST` travels down. See [Mesh Topology](../concepts/mesh.md). |
 | **`site_id`** | A label identifying the physical location or grouping of a node (e.g. a room or building), used for routing and addressing within a hive. |
-| **Session** | The per-client context a hub maintains for each connected satellite — independent permissions, identity, and conversational state. |
+| **Session** | The per-client context a hivemind-core instance maintains for each connected satellite — independent permissions, identity, and conversational state. |
+
+---
 
 ## Protocol
 
 | Term | Definition |
 |---|---|
-| **HiveMind protocol** | The encrypted message protocol satellites and hubs speak. Transport-agnostic; WebSocket is the default. See [Protocol & Message Types](../concepts/protocol.md) and the [Protocol Specification](../developers/protocol-spec.md). |
+| **HiveMind protocol** | The encrypted message protocol satellites and hivemind-core instances speak. Transport-agnostic; WebSocket is the default. See [Protocol & Message Types](../concepts/protocol.md) and the [Protocol Specification](../developers/protocol-spec.md). |
 | **Handshake** | The connection setup that derives a shared session key (PBKDF2-HMAC-SHA256, 100 000 iterations) and establishes an encrypted channel using ChaCha20-Poly1305 or AES-GCM, backed by per-node RSA identities. See [Security & Permissions](../concepts/security.md). |
 | <span id="bus-message"></span>**BUS message** | An OVOS `messagebus` message carried over the hive, the primary payload type for utterances and responses. |
 | **Bus message types** | The transport verbs that route messages through the mesh: `ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM` (defined individually below). See [Message Types](message-types.md). |
-| **`ESCALATE`** | A message sent *upward* to a parent hub when a node cannot handle a request locally. |
-| **`BROADCAST`** | A message sent *downward* from a hub to all of its satellites at once. |
+| **`ESCALATE`** | A message sent *upward* to a parent hivemind-core instance when a node cannot handle a request locally. |
+| **`BROADCAST`** | A message sent *downward* from hivemind-core to all of its satellites at once. |
 | **`PROPAGATE`** | A message flooded in *all* directions across the hive (used for announcements and topology discovery). |
 | **`QUERY`** | A routed request that expects exactly one answer, which travels back to whoever asked. |
 | **`CASCADE`** | A scatter/gather request: every reachable node may answer, and a select-callback picks the best reply. |
 | **`INTERCOM`** | An end-to-end encrypted message addressed to one specific node; relays along the way cannot read it. |
-| **Agent protocol** | The pluggable AI back-end a hub uses to actually answer natural-language queries — OVOS skills, an LLM persona, or a Google A2A agent. See [Plugin Architecture](../concepts/plugins.md). |
-| **A2A (Agent-to-Agent)** | Google's open Agent-to-Agent protocol; a HiveMind hub can use an A2A agent as its back-end via the `hivemind-a2a-agent-plugin`. |
+| **Agent protocol** | The pluggable AI back-end hivemind-core uses to actually answer natural-language queries — OVOS skills, an LLM persona, or a Google A2A agent. See [Plugin Architecture](../concepts/plugins.md). |
+| **A2A (Agent-to-Agent)** | Google's open Agent-to-Agent protocol; hivemind-core can use an A2A agent as its back-end via the `hivemind-a2a-agent-plugin`. |
 | **Network protocol / transport** | The pluggable carrier that moves HiveMind messages between nodes — WebSocket (default), HTTP polling, or MQTT. Transport-agnostic: the same protocol runs over any of them. |
 | **Binary protocol** | The framing used to carry raw audio (and other binary payloads) over the hive for server-side STT/TTS. See [Audio Binary Protocol](../server/audio-binary-protocol.md). |
 | **Permission / policy** | The deny-by-default rules that decide which message types and skills a given client may use, enforced as a policy chain. A new client is **fail-closed**: it can send nothing until a type is explicitly allowed. See [Security & Permissions](../concepts/security.md). |
 | **PBKDF2** | The password-stretching function (PBKDF2-HMAC-SHA256, 100 000 iterations) that turns a client's password into the shared session encryption key during the handshake. |
 | **AES-GCM** | A symmetric authenticated-encryption cipher used (alongside ChaCha20-Poly1305) to encrypt every message on the wire after the handshake. |
 
+---
+
 ## Credentials & access control
 
 | Term | Definition |
 |---|---|
-| **Access key** | The per-client identifier a satellite presents to a hub when connecting — the "username" half of its credentials. Issued by `hivemind-core add-client`. |
+| **Access key** | The per-client identifier a satellite presents to hivemind-core when connecting — the "username" half of its credentials. Issued by `hivemind-core add-client`. |
 | **Password** | The per-client secret used during the handshake to derive the encryption key (via [PBKDF2](#protocol)). The "password" half of a client's credentials. |
-| **Identity file** | `~/.config/hivemind/_identity.json` on a satellite — stores its access key, password, hub address, `site_id`, and RSA keys so it can reconnect without re-entering credentials. Written by `hivemind-client set-identity`. |
+| **Identity file** | `~/.config/hivemind/_identity.json` on a satellite — stores its access key, password, hivemind-core address, `site_id`, and RSA keys so it can reconnect without re-entering credentials. Written by `hivemind-client set-identity`. |
 | **ACL / allowlist** | The list of OVOS message types a given client is permitted to send (`allowed_types`). Deny-by-default: anything not on the list is rejected. |
 | **`allow-msg`** | The `hivemind-core` command that adds a message type to a client's allowlist (its counterpart, `blacklist-msg`, removes one). A brand-new client must be granted at least one type before it can do anything. |
 | **`blacklist-skill`** | The `hivemind-core` command that forbids a specific OVOS skill for a client; enforced by the OVOS agent policy. (`allow-skill` reverses it.) |
+
+---
 
 ## Discovery
 
 | Term | Definition |
 |---|---|
-| **HiveBeacon** | A planned zero-dependency UDP-broadcast auto-discovery transport, intended to become the default once it ships. Not yet implemented — the current default LAN discovery transport is mDNS/Zeroconf (with UPnP/SSDP as an off-by-default legacy option). See [Auto Discovery](../concepts/discovery.md). |
+| **HiveBeacon** | A planned zero-dependency UDP-broadcast auto-discovery transport. The default LAN discovery transport is mDNS/Zeroconf (with UPnP/SSDP as an off-by-default legacy option). See [Auto Discovery](../concepts/discovery.md). |
 | **GGWave pairing** | An audio-based pairing mechanism that exchanges connection details over sound. Proof-of-concept. See [Auto Discovery](../concepts/discovery.md). |
+
+---
 
 ## OVOS & voice vocabulary
 
-Terms a HiveMind user runs into that come from the OVOS voice stack a hub runs.
+Terms a HiveMind user runs into that come from the OVOS voice stack hivemind-core runs.
 
 | Term | Definition |
 |---|---|
-| **OVOS (OpenVoiceOS)** | The open-source voice assistant platform a HiveMind hub runs skills on. See [openvoiceos.org](https://openvoiceos.org). |
-| **ovos-core** | The skills/intent engine — the default HiveMind hub agent. |
-| **messagebus / ovos-messagebus** | OVOS's internal websocket event bus that skills and services communicate over locally. It is distinct from the HiveMind protocol, which is what a hub and its satellites speak; a BUS message carries an OVOS `messagebus` message across the hive. |
+| **OVOS (OpenVoiceOS)** | The open-source voice assistant platform hivemind-core runs skills on. See [openvoiceos.org](https://openvoiceos.org). |
+| **ovos-core** | The skills/intent engine — the default HiveMind agent. |
+| **messagebus / ovos-messagebus** | OVOS's internal websocket event bus that skills and services communicate over locally. It is distinct from the HiveMind protocol, which is what hivemind-core and its satellites speak; a BUS message carries an OVOS `messagebus` message across the hive. |
 | **Skill** | A plugin that handles a category of intents (weather, timers, etc.). |
 | **Intent** | The parsed meaning of an utterance, used to route it to a skill. |
 | <span id="utterance"></span>**Utterance** | A transcribed line of user speech (or typed text). |
@@ -84,11 +98,13 @@ Terms a HiveMind user runs into that come from the OVOS voice stack a hub runs.
 | **STT (Speech-to-Text)** | Transcribes audio into text. |
 | **TTS (Text-to-Speech)** | Synthesizes spoken audio from text. |
 | **Solver** | An `ovos-persona` plugin that answers a query (e.g. an LLM backend); personas chain solvers together. |
-| **Persona** | An `ovos-persona` config — a named chain of solvers — that a [Persona Hub](../server/persona-hub.md) serves instead of full skills. |
+| **Persona** | An `ovos-persona` config — a named chain of solvers — that a [Persona backend](../server/persona-hub.md) serves instead of full skills. |
 | <span id="ocp-ovos-common-play"></span>**OCP (OVOS Common Play)** | The OVOS media/audio playback framework. |
 | **PHAL** | OVOS's Platform Hardware Abstraction Layer — plugins for volume, system control, and similar; relevant to the Home Assistant integration's permission list. |
+
+---
 
 ## See also
 
 - [Protocol & Message Types](../concepts/protocol.md) — how the message verbs above route through a hive
-- [Mesh & Hub Topology](../concepts/mesh.md) — how hubs, satellites, and nested hives fit together
+- [Mesh Topology](../concepts/mesh.md) — how hivemind-core instances, satellites, and nested hives fit together

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,6 @@
 # Reference
 
-Look-it-up material: exhaustive tables you scan, not tutorials you read. When you need
-the exact flag, key, or value, it's here.
+**The reference section is look-it-up material — exhaustive tables you scan, not tutorials you read.** When you need the exact flag, key, or value, it is here.
 
 | Page | Look here for |
 |---|---|
@@ -11,7 +10,7 @@ the exact flag, key, or value, it's here.
 | [Glossary](glossary.md) | Plain-language definition of every term in this manual. |
 
 !!! tip "Brand new? Start at the Glossary."
-    If a word on any page is unfamiliar — *satellite, hub, escalate, intercom, ACL* —
+    If a word on any page is unfamiliar — *satellite, hivemind-core, escalate, intercom, ACL* —
     the [Glossary](glossary.md) defines it in one line. Keep it open in a second tab.
 
 ---

--- a/docs/reference/message-types.md
+++ b/docs/reference/message-types.md
@@ -1,19 +1,27 @@
 # HiveMessage Types Reference
 
-> **What this is.** A lookup table of every kind of message that travels over a HiveMind network — what each one is for, which direction it flows, and what it carries. Skim the [Quick reference](#quick-reference) first; reach for the per-type sections when you need the details.
+**A lookup table of every kind of message that travels over a HiveMind network** — what each one is for, which direction it flows, and what it carries.
+
+!!! abstract "In a nutshell"
+    - Message types fall into **payload** (`BUS`, `SHARED_BUS`, `THIRDPRTY`, `BINARY`), **transport** (`ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM`, `RENDEZVOUS`), **discovery** (`PING`), and **connection** (`HELLO`, `HANDSHAKE`) categories.
+    - Transport verbs wrap another `HiveMessage` to route it up (`ESCALATE`), down (`BROADCAST`), or everywhere (`PROPAGATE`).
+    - `QUERY` expects one correlated response; `CASCADE` is scatter/gather with a select callback.
+    - Skim the [Quick reference](#quick-reference) table first; reach for the per-type sections for details.
 
 All message types are defined in `HiveMessageType` in `hivemind_bus_client.message`.
+
+---
 
 ## Quick reference
 
 | Type | Category | Direction | Purpose |
 |---|---|---|---|
 | `BUS` | Payload | Bidirectional | Single-hop message to/from AI back-end |
-| `SHARED_BUS` | Payload | Satellite → Hub | Passive monitoring of satellite's local OVOS bus |
+| `SHARED_BUS` | Payload | Satellite → hivemind-core | Passive monitoring of satellite's local OVOS bus |
 | `THIRDPRTY` | Payload | Application-defined | User-defined payload, relayed opaquely |
 | `BINARY` | Payload | Bidirectional | Raw binary data (audio, images, files) |
-| `ESCALATE` | Transport | Satellite → Hub (up) | Multi-hop upward routing |
-| `BROADCAST` | Transport | Hub → All (down) | Multi-hop downward routing |
+| `ESCALATE` | Transport | Satellite → hivemind-core (up) | Multi-hop upward routing |
+| `BROADCAST` | Transport | hivemind-core → All (down) | Multi-hop downward routing |
 | `PROPAGATE` | Transport | Bidirectional | All-directions flood |
 | `QUERY` | Transport | Bidirectional | Routed request with a single expected response |
 | `CASCADE` | Transport | Bidirectional | Scatter/gather — all nodes may respond |
@@ -23,21 +31,27 @@ All message types are defined in `HiveMessageType` in `hivemind_bus_client.messa
 | `HELLO` | Connection | Bidirectional | Node announcement on connect |
 | `HANDSHAKE` | Connection | Bidirectional | Cryptographic key exchange |
 
+---
+
 ## BUS
 
-Standard single-hop message between satellite and hub.
+Standard single-hop message between satellite and hivemind-core.
 
 - **Payload**: OVOS `Message` object
-- **Hub behaviour**: checks `allowed_types`, runs policy chain, injects into OVOS bus, routes replies back
+- **hivemind-core behaviour**: checks `allowed_types`, runs policy chain, injects into OVOS bus, routes replies back
 - **Satellite behaviour**: send utterances and other OVOS messages; listen for responses
+
+---
 
 ## SHARED_BUS
 
 Passive monitoring of the satellite's local OVOS bus.
 
-- **Direction**: satellite → hub
-- **Hub behaviour**: observes without injecting into the local bus
+- **Direction**: satellite → hivemind-core
+- **hivemind-core behaviour**: observes without injecting into the local bus
 - **Use**: typically via [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind)
+
+---
 
 ## BINARY
 
@@ -56,15 +70,19 @@ Raw binary payload.
 | 3 | FILE | File transfer |
 | 4 | STT_AUDIO_TRANSCRIBE | Full utterance → return transcript |
 | 5 | STT_AUDIO_HANDLE | Full utterance → transcribe and handle intent |
-| 6 | TTS_AUDIO | Synthesized speech (hub → satellite) |
+| 6 | TTS_AUDIO | Synthesized speech (hivemind-core → satellite) |
+
+---
 
 ## ESCALATE
 
-Wraps another `HiveMessage` and routes it upward through the hub chain.
+Wraps another `HiveMessage` and routes it upward through the hivemind-core chain.
 
 - **Payload**: a nested `HiveMessage`
 - **Hop limit**: finite; loops are prevented
-- **Use**: satellite cannot handle a request locally; asks the parent hub
+- **Use**: satellite cannot handle a request locally; asks the parent hivemind-core
+
+---
 
 ## BROADCAST
 
@@ -72,7 +90,9 @@ Wraps another `HiveMessage` and routes it downward to all satellites.
 
 - **Payload**: a nested `HiveMessage`
 - **Target filtering**: supports `target_site_id` to reach only satellites in a specific location
-- **Sent by**: hub (typically triggered by a skill)
+- **Sent by**: hivemind-core (typically triggered by a skill)
+
+---
 
 ## PROPAGATE
 
@@ -81,14 +101,16 @@ Wraps another `HiveMessage` and floods it in all directions.
 - **Payload**: a nested `HiveMessage`
 - **Use**: mesh-wide announcements, topology discovery (PING is always wrapped in PROPAGATE)
 
+---
+
 ## QUERY
 
 A routed request that expects exactly one response, correlated by a `query_id`. Like `ESCALATE`, but the response travels back to the originator.
 
 - **Payload**: a nested `HiveMessage` (typically wrapping a `BUS` message)
 - **Permission**: the sending client must have `can_escalate = True`
-- **Hub behaviour (request)**: the hub attempts to answer from its local agent (within a timeout). If the local agent answers, a QUERY response is sent back immediately. If not, the request is forwarded upstream via `query_to_master`. At the top-level master with no upstream, a `hive.query.timeout` error response is returned.
-- **Hub behaviour (response)**: messages with `metadata["is_response"] = True` are routed downstream toward the originator identified by `metadata["originator_peer"]`.
+- **hivemind-core behaviour (request)**: hivemind-core attempts to answer from its local agent (within a timeout). If the local agent answers, a QUERY response is sent back immediately. If not, the request is forwarded upstream via `query_to_master`. At the top-level master with no upstream, a `hive.query.timeout` error response is returned.
+- **hivemind-core behaviour (response)**: messages with `metadata["is_response"] = True` are routed downstream toward the originator identified by `metadata["originator_peer"]`.
 - **Response metadata fields**:
 
 | Field | Description |
@@ -100,17 +122,21 @@ A routed request that expects exactly one response, correlated by a `query_id`. 
 
 The response payload wraps an inner `BUS` HiveMessage; the inner BUS message carries the OVOS agent's reply.
 
+---
+
 ## CASCADE
 
 A scatter/gather request: like `PROPAGATE`, but every reachable node may answer. Responses are collected and a **select callback** disambiguates to pick the best answer.
 
 - **Payload**: a nested `HiveMessage` (wrapping a `BUS` message)
 - **Permission**: the sending client must have `can_propagate = True`
-- **Hub behaviour (request)**: the hub tries its local agent, then forwards the CASCADE to all other connected peers and upstream. Every node that can answer sends a response.
-- **Hub behaviour (response)**: response messages (`is_response = True`) are routed back toward the originator. At the originator's hub, a `cascade_select_callback` (if configured) collects all responses and picks a winner. Without a select callback, each response is forwarded individually.
+- **hivemind-core behaviour (request)**: hivemind-core tries its local agent, then forwards the CASCADE to all other connected peers and upstream. Every node that can answer sends a response.
+- **hivemind-core behaviour (response)**: response messages (`is_response = True`) are routed back toward the originator. At the originator's hivemind-core, a `cascade_select_callback` (if configured) collects all responses and picks a winner. Without a select callback, each response is forwarded individually.
 - **Client behaviour**: `CascadeAggregator` on the client side buffers responses for a `cascade_timeout` window (default 5 s). Once the timer expires — or the expected number of responses has arrived — the `cascade_select_callback` picks the best response and delivers it.
 - **Trust**: unlike QUERY responses (which come from a known upstream node), CASCADE responses can originate from any node in the hive. The select callback is responsible for choosing among potentially untrusted responses.
 - **Response metadata fields**: same as QUERY (`query_id`, `originator_peer`, `responder_peer`, `is_response`).
+
+---
 
 ## INTERCOM
 
@@ -121,6 +147,8 @@ End-to-end encrypted point-to-point message.
 - **Routing**: typically wrapped in ESCALATE or PROPAGATE to reach the target
 - **Intermediate nodes**: cannot read the content or determine the recipient
 
+---
+
 ## PING
 
 Topology discovery.
@@ -129,6 +157,8 @@ Topology discovery.
 - There is no `PONG` reply type. Every node that receives a `PING` re-emits its own `PING` with the same `flood_id`, flooded onward via `PROPAGATE`; receivers deduplicate by `flood_id`
 - **Payload**: `{flood_id, peer, site_id, timestamp}`
 - `HiveMapper` in `hivemind_core.hive_map` observes the re-emitted PINGs to build a live topology map
+
+---
 
 ## HELLO / HANDSHAKE
 
@@ -146,13 +176,19 @@ Connection management. Handled automatically by `HiveMessageBusClient` and `hive
 >
 > For the full connection-setup sequence with exact field tables in both directions, see the [Handshake state machine](../developers/protocol-spec.md#handshake-state-machine) in the protocol spec.
 
+---
+
 ## RENDEZVOUS
 
-Reserved for rendezvous-nodes. Defined in the `HiveMessageType` enum but not yet wired into general routing.
+Reserved for rendezvous-nodes. Defined in the `HiveMessageType` enum but not wired into general routing.
+
+---
 
 ## THIRDPRTY
 
-User-defined payload. Relayed opaquely by the hub without any special processing. Use it for application-level protocols layered on top of HiveMind.
+User-defined payload. Relayed opaquely by hivemind-core without any special processing. Use it for application-level protocols layered on top of HiveMind.
+
+---
 
 ## Source
 

--- a/docs/satellites/cli.md
+++ b/docs/satellites/cli.md
@@ -1,17 +1,23 @@
 # HiveMind CLI
 
-The simplest HiveMind satellite — text only, no audio hardware required.
+**HiveMind-cli is the simplest satellite — a text-only terminal client that needs no audio hardware.** You type utterances and hivemind-core does everything; responses arrive as text.
 
-**What runs locally**: A CLI interface. No audio processing whatsoever.
+!!! abstract "In a nutshell"
+    - **Runs locally**: a terminal interface — no audio processing at all.
+    - **hivemind-core provides**: STT, TTS, skills, and intents; replies come back as text.
+    - Installs as the `hivemind-cli` console script (`pip install HiveMind-cli`).
+    - Ideal for testing hivemind-core instances and skills, scripting, and audio-less IoT devices.
 
-**What the hub provides**: All processing (STT, TTS, skills, intents). Responses arrive as text.
+---
 
 ## When to use it
 
-- Testing and debugging a hub or a skill
+- Testing and debugging a hivemind-core instance or a skill
 - Scripting and automation from a server
 - IoT devices with network connectivity but no audio hardware
 - Any scenario where you want to interact via keyboard or piped input
+
+---
 
 ## Install
 
@@ -21,6 +27,8 @@ pip install HiveMind-cli
 
 This provides the `hivemind-cli` console script — a terminal client with no
 subcommands, just flags.
+
+---
 
 ## Usage
 
@@ -40,6 +48,8 @@ Plain output (no curses UI) for scripting or SSH sessions:
 hivemind-cli --access-key <key> --password <password> --host wss://192.168.1.10 --no-curses
 ```
 
+---
+
 ## CLI flags
 
 | Flag | Default | Description |
@@ -51,6 +61,8 @@ hivemind-cli --access-key <key> --password <password> --host wss://192.168.1.10 
 | `--no-curses` | off | Disable the curses UI; use plain stdout/stdin instead. |
 | `--self-signed` | off | Accept self-signed SSL certificates. |
 
+---
+
 ## See also
 
 For scriptable, non-interactive use, the `hivemind-client` command from the
@@ -58,9 +70,13 @@ For scriptable, non-interactive use, the `hivemind-client` command from the
 package offers subcommands such as `set-identity`, `terminal`, `send-mycroft`,
 `escalate`, `propagate`, and `ping`. That is a separate package from `HiveMind-cli`.
 
+---
+
 ## Next
 
 New to HiveMind? Start with the [Quick Start](../quickstart.md), or learn how the pieces fit in [Core Concepts](../concepts/mesh.md).
+
+---
 
 ## Source
 

--- a/docs/satellites/index.md
+++ b/docs/satellites/index.md
@@ -1,49 +1,63 @@
 # Choosing a Satellite
 
-HiveMind satellites form a spectrum based on **where audio processing happens**. Choose the right satellite for your hardware and use case.
+**HiveMind satellites form a spectrum defined by where audio processing happens** — from a text-only terminal, through microcontrollers and microphones processed by hivemind-core, up to a full local voice stack. Choose the one that fits your hardware and use case.
+
+!!! abstract "In a nutshell"
+    - Satellites differ by **which stages run on the device** (mic, VAD, wakeword, STT, TTS) and **what crosses the wire** (text, raw audio, or audio after wakeword).
+    - Audio satellites need matching server support: raw-audio and base64-audio clients require `hivemind-audio-binary-protocol`; text satellites work with any hivemind-core instance.
+    - The [voice satellite](voice-sat.md) keeps all speech local and sends only text; the [mic satellite](mic-satellite.md) is the cheapest device but puts STT/TTS on hivemind-core.
+    - Use the [decision guide](#decision-guide) to map a device to its satellite.
+
+---
 
 ## Comparison
 
-**Most people start with the voice satellite** (everything runs locally, works with any hub) or the **mic satellite** (cheapest device, but the hub must do STT/TTS). Pick from the table below, or read the decision guide.
+**Most people start with the voice satellite** (everything runs locally, works with any hivemind-core instance) or the **mic satellite** (cheapest device, but hivemind-core must do STT/TTS). Pick from the table below, or read the decision guide.
 
 | Satellite | Mic | VAD | Wakeword | STT | TTS | What crosses the wire |
 |---|:---:|:---:|:---:|:---:|:---:|---|
 | [HiveMind-cli](cli.md) | — | — | — | — | — | Text in / text out |
-| [Microcontrollers (ESP32)](microcontrollers.md) | local | local[^esp] | local[^esp] | **hub** | **hub** | Raw audio stream |
-| [hivemind-mic-satellite](mic-satellite.md) | local | local | **hub** | **hub** | **hub** | Raw audio stream |
-| [HiveMind-voice-relay](voice-relay.md) | local | local | local | **hub** | **hub** | Audio after wakeword |
+| [Microcontrollers (ESP32)](microcontrollers.md) | local | local[^esp] | local[^esp] | **server** | **server** | Raw audio stream |
+| [hivemind-mic-satellite](mic-satellite.md) | local | local | **server** | **server** | **server** | Raw audio stream |
+| [HiveMind-voice-relay](voice-relay.md) | local | local | local | **server** | **server** | Audio after wakeword |
 | [HiveMind-voice-sat](voice-sat.md) | local | local | local | local | local | Text utterances only |
-| [WebSpeech Browser](webspeech.md) | browser | browser | — | **hub** | **hub** | Audio from browser |
+| [WebSpeech Browser](webspeech.md) | browser | browser | — | **server** | **server** | Audio from browser |
 
-[^esp]: On-device VAD and wakeword apply to the ESP32-S3 Voice PE build (ESP-SR WakeNet9); the plain ESP32 and the MicroPython client capture the mic and let the hub do the rest. See [Microcontrollers](microcontrollers.md).
+[^esp]: On-device VAD and wakeword apply to the ESP32-S3 Voice PE build (ESP-SR WakeNet9); the plain ESP32 and the MicroPython client capture the mic and let hivemind-core do the rest. See [Microcontrollers](microcontrollers.md).
 
 The **microcontroller** clients (ESP32 in C, or MicroPython) are the thinnest *hardware* tier — below the mic satellite. They turn a tiny chip into a satellite without running OVOS or Python-on-a-PC on the device. See [Microcontrollers (ESP32)](microcontrollers.md).
 
-## Hub requirements by satellite
+---
 
-| Satellite | Hub must provide |
+## Server requirements by satellite
+
+| Satellite | hivemind-core must provide |
 |---|---|
-| HiveMind-cli | Any hub (OVOS skills or Persona) |
+| HiveMind-cli | Any hivemind-core instance (OVOS skills or Persona) |
 | Microcontrollers (ESP32) | `hivemind-audio-binary-protocol` for the binary/base64 audio modes |
 | hivemind-mic-satellite | `hivemind-audio-binary-protocol` for STT/TTS/wakeword |
 | HiveMind-voice-relay | `hivemind-audio-binary-protocol` for STT/TTS |
-| HiveMind-voice-sat | Any hub (sends text utterances) |
+| HiveMind-voice-sat | Any hivemind-core instance (sends text utterances) |
 | WebSpeech Browser | `ovos-dinkum-listener >= 0.0.3a19` + `hivemind-core allow-msg "recognizer_loop:b64_audio"` |
 
-See [Audio Binary Protocol](../server/audio-binary-protocol.md) for hub-side setup.
+See [Audio Binary Protocol](../server/audio-binary-protocol.md) for server-side setup.
+
+---
 
 !!! note "Advanced: how the audio actually travels"
-    The audio satellites do not all use the same transport, which is why their hub
+    The audio satellites do not all use the same transport, which is why their server
     requirements differ:
 
     - **mic-satellite** and the **ESP32 binary mode** send **binary `RAW_AUDIO`**
-      frames — handled by `hivemind-audio-binary-protocol` on the hub.
+      frames — handled by `hivemind-audio-binary-protocol` on hivemind-core.
     - **voice-relay** sends **base64 audio over the bus**
       (`recognizer_loop:b64_transcribe`; TTS comes back as `speak:b64_audio`) — also
       provided by `hivemind-audio-binary-protocol`.
     - **WebSpeech** sends **base64 audio over the bus** as `recognizer_loop:b64_audio`,
-      which is decoded directly by `ovos-dinkum-listener >= 0.0.3a19` once the hub
+      which is decoded directly by `ovos-dinkum-listener >= 0.0.3a19` once hivemind-core
       allows that message — it does **not** use the binary `RAW_AUDIO` protocol.
+
+---
 
 ## Decision guide
 
@@ -61,34 +75,42 @@ See [Audio Binary Protocol](../server/audio-binary-protocol.md) for hub-side set
    - No → continue
 
 4. **Do you need a wakeword on the device?** (saves bandwidth; needed for service-at-scale)
-   - Yes → use **HiveMind-voice-relay** (local wakeword; STT/TTS on hub)
-   - No → use **hivemind-mic-satellite** (cheapest hardware; everything on hub)
+   - Yes → use **HiveMind-voice-relay** (local wakeword; STT/TTS on hivemind-core)
+   - No → use **hivemind-mic-satellite** (cheapest hardware; everything on hivemind-core)
 
 5. **Is this a web browser or web app?**
    - Yes → use **WebSpeech Browser**
 
-## About hub-owned STT/TTS
+---
 
-When a satellite uses hub-side audio processing (mic-satellite or voice-relay), the hub operator decides the STT engine, TTS engine, and voice — the satellite cannot override them. This is the "HiveMind as a service" model: speech services are authenticated and centrally governed, like any other message on the protocol.
+## About server-owned STT/TTS
 
-A voice-sat by contrast runs its own STT and TTS plugins and sends only the transcribed text to the hub. It has full control over its local audio stack.
+When a satellite uses server-side audio processing (mic-satellite or voice-relay), the hivemind-core operator decides the STT engine, TTS engine, and voice — the satellite cannot override them. This is the "HiveMind as a service" model: speech services are authenticated and centrally governed, like any other message on the protocol.
+
+A voice-sat by contrast runs its own STT and TTS plugins and sends only the transcribed text to hivemind-core. It has full control over its local audio stack.
+
+---
 
 ## See also
 
 - **Multi-user text chatroom** — [hivemind-flask-chatroom](https://github.com/JarbasHiveMind/hivemind-flask-chatroom)
   is a text-only Flask web app (default port `8985`, no audio) where one server-side
   credential is fanned out to many browser visitors. Handy for a shared text terminal
-  to a hub; it is not a per-device satellite.
+  to a hivemind-core instance; it is not a per-device satellite.
+
+---
 
 ## Next
 
 Head to the satellite that fits your device: [Microcontrollers (ESP32)](microcontrollers.md), [HiveMind-voice-sat](voice-sat.md), [hivemind-mic-satellite](mic-satellite.md), [HiveMind-voice-relay](voice-relay.md), [HiveMind-cli](cli.md), or [WebSpeech Browser](webspeech.md).
 
+---
+
 ## Source
 
 Validated against the HiveMind source:
 
-- [`docs/configuration.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/docs/configuration.md) — WebSpeech hub requirement (`ovos-dinkum-listener` + `allow-msg "recognizer_loop:b64_audio"`)
+- [`docs/configuration.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/docs/configuration.md) — WebSpeech server requirement (`ovos-dinkum-listener` + `allow-msg "recognizer_loop:b64_audio"`)
 - [`hivemind_voice_relay/service.py`](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/HEAD/hivemind_voice_relay/service.py) — voice-relay base64-over-bus transport (`recognizer_loop:b64_transcribe` / `speak:b64_audio`)
 - [`hivemind_mic_sat/__init__.py`](https://github.com/JarbasHiveMind/hivemind-mic-satellite/blob/HEAD/hivemind_mic_sat/__init__.py) — mic-satellite binary `RAW_AUDIO` transport
 - [`README.md`](https://github.com/JarbasHiveMind/hivemind-esp32-client/blob/HEAD/README.md) — ESP32 satellite tier

--- a/docs/satellites/mic-satellite.md
+++ b/docs/satellites/mic-satellite.md
@@ -1,10 +1,14 @@
 # Microphone Satellite
 
-The thinnest HiveMind satellite. Runs microphone capture and Voice Activity Detection (VAD) on-device; everything else — wakeword detection, STT, intent handling, TTS synthesis — runs on the hub.
+**The mic satellite is the thinnest software satellite: it runs only microphone capture and Voice Activity Detection (VAD) on-device.** Everything else — wakeword detection, STT, intent handling, and TTS synthesis — runs on hivemind-core.
 
-**What runs locally**: Microphone + VAD
+!!! abstract "In a nutshell"
+    - **Runs locally**: microphone + VAD.
+    - **hivemind-core provides**: wakeword, STT, intent processing, and TTS — requires `hivemind-audio-binary-protocol` on hivemind-core.
+    - Streams every VAD-gated voice segment to hivemind-core as binary `RAW_AUDIO`, so it is bandwidth-heavy and best suited to a small LAN homelab.
+    - For multi-user or at-scale deployments, prefer [voice-relay](voice-relay.md), which gates audio behind a local wakeword.
 
-**What the hub provides**: Wakeword, STT, intent processing, TTS (requires `hivemind-audio-binary-protocol` on the hub)
+---
 
 ## When to use it
 
@@ -12,9 +16,13 @@ The thinnest HiveMind satellite. Runs microphone capture and Voice Activity Dete
 - Scenarios where you want zero local model downloads
 - Personal homelab with a handful of devices on a fast LAN
 
+---
+
 ## When not to use it
 
-mic-satellite streams every detected voice segment to the hub continuously (VAD-gated but not wakeword-gated). This is bandwidth-intensive and puts the full STT load on the server for all speech activity. It is appropriate for a small homelab. For a deployment serving multiple users, prefer [voice-relay](voice-relay.md) — local wakeword means audio only leaves the device after activation.
+mic-satellite streams every detected voice segment to hivemind-core continuously (VAD-gated but not wakeword-gated). This is bandwidth-intensive and puts the full STT load on the server for all speech activity. It is appropriate for a small homelab. For a deployment serving multiple users, prefer [voice-relay](voice-relay.md) — local wakeword means audio only leaves the device after activation.
+
+---
 
 ## Install
 
@@ -24,17 +32,21 @@ pip install hivemind-mic-satellite
 
 Requires Python ≥ 3.10.
 
-## Hub requirements
+---
 
-The hub must have `hivemind-audio-binary-protocol` installed and configured. Plain `hivemind-core` does not handle audio.
+## Server requirements
+
+hivemind-core must have `hivemind-audio-binary-protocol` installed and configured. On its own, hivemind-core does not handle audio.
 
 See [Audio Binary Protocol](../server/audio-binary-protocol.md).
 
+---
+
 ## Quickstart
 
-> **Pre-flight:** this satellite sends audio to the hub, so **the hub MUST have the [Audio Binary Protocol](../server/audio-binary-protocol.md) configured** — it provides the VAD-gated STT, TTS, and wakeword. Without it the satellite connects but its audio is silently dropped, with no error.
+> **Pre-flight:** this satellite sends audio to hivemind-core, so **hivemind-core MUST have the [Audio Binary Protocol](../server/audio-binary-protocol.md) configured** — it provides the VAD-gated STT, TTS, and wakeword. Without it the satellite connects but its audio is silently dropped, with no error.
 
-**1. On the hub** — register a client:
+**1. On hivemind-core** — register a client:
 
 ```bash
 hivemind-core add-client --name my-mic-sat
@@ -47,7 +59,7 @@ hivemind-core add-client --name my-mic-sat
 hivemind-client set-identity \
   --key <access_key> \
   --password <password> \
-  --host <hub_host_or_ip>
+  --host <server_host_or_ip>
 ```
 
 **3. Run:**
@@ -66,9 +78,11 @@ The full flag set is `--key --password --host --port --siteid`. Each falls back 
 identity file written by `hivemind-client set-identity`.
 
 !!! note
-    mic-satellite has **no** `--selfsigned` flag. If your hub uses a self-signed
+    mic-satellite has **no** `--selfsigned` flag. If hivemind-core uses a self-signed
     certificate, prefer a plain `ws://` LAN connection or a properly issued
     certificate.
+
+---
 
 ## Configuration
 
@@ -95,10 +109,12 @@ Example `mycroft.conf` excerpt:
 }
 ```
 
+---
+
 ## How audio flows
 
 ```
-[Microphone] → [VAD] → raw audio chunks → [HiveMind Hub]
+[Microphone] → [VAD] → raw audio chunks → [hivemind-core]
                                               ↓
                                     [hivemind-audio-binary-protocol]
                                               ↓
@@ -109,15 +125,19 @@ Example `mycroft.conf` excerpt:
                                     [Satellite plays TTS audio]
 ```
 
-Audio is sent as `BINARY` messages with payload type `RAW_AUDIO` (type 1). The hub's `AudioBinaryProtocol.handle_microphone_input()` processes the stream.
+Audio is sent as `BINARY` messages with payload type `RAW_AUDIO` (type 1). hivemind-core's `AudioBinaryProtocol.handle_microphone_input()` processes the stream.
+
+---
 
 ## Next
 
-Set up the hub side: [Audio Binary Protocol](../server/audio-binary-protocol.md).
+Set up the server side: [Audio Binary Protocol](../server/audio-binary-protocol.md).
+
+---
 
 ## Source
 
 Validated against the HiveMind source:
 
 - [`hivemind_mic_sat/__init__.py`](https://github.com/JarbasHiveMind/hivemind-mic-satellite/blob/HEAD/hivemind_mic_sat/__init__.py) — CLI flags (`--key --password --host --port --siteid`) and the binary `RAW_AUDIO` transport
-- [`docs/architecture.md`](https://github.com/JarbasHiveMind/hivemind-mic-satellite/blob/HEAD/docs/architecture.md) — audio flow and hub-side processing
+- [`docs/architecture.md`](https://github.com/JarbasHiveMind/hivemind-mic-satellite/blob/HEAD/docs/architecture.md) — audio flow and server-side processing

--- a/docs/satellites/microcontrollers.md
+++ b/docs/satellites/microcontrollers.md
@@ -1,11 +1,17 @@
 # Microcontrollers (ESP32)
 
-The thinnest possible *hardware* satellite. These clients turn a bare
-microcontroller — an ESP32, or a Raspberry Pi Pico W — into a HiveMind
-[satellite](../reference/glossary.md), without running OVOS or a full Python desktop
-on the device. The chip captures the microphone and ships audio to the
-[hub](../reference/glossary.md); the hub does all the speech-to-text, intents, skills,
+**The microcontroller clients are the thinnest possible *hardware* satellites** — they turn a bare
+microcontroller (an ESP32, or a Raspberry Pi Pico W) into a HiveMind
+[satellite](../reference/glossary.md) without running OVOS or a full Python desktop
+on the device. The chip captures the microphone and ships audio to
+[hivemind-core](../reference/glossary.md); hivemind-core does all the speech-to-text, intents, skills,
 and text-to-speech.
+
+!!! abstract "In a nutshell"
+    - Two clients: **ESP32 (C / ESP-IDF)** for maximum control and on-device wakeword, and **MicroPython** for pure-Python hacking.
+    - STT, TTS, and intents run on hivemind-core; the two HiveMind audio modes need `hivemind-audio-binary-protocol` on hivemind-core.
+    - On protocol v3 the session uses a Noise handshake with a [provisioned PSK](#provisioned-psk) pre-computed on hivemind-core, since argon2id is too heavy to derive on-device.
+    - Devices connect over plain `ws://` — confidentiality comes from the handshake, not TLS — so keep them on a trusted network.
 
 There are two clients, depending on the language you want to work in:
 
@@ -17,8 +23,8 @@ There are two clients, depending on the language you want to work in:
     Choose **C / ESP-IDF** for the most control, the best performance, and the only
     on-device wakeword path (ESP32-S3 Voice PE). Choose **MicroPython** if you would
     rather write Python and value quick iteration over raw efficiency. Both speak the
-    same HiveMind protocol to the same hub, including **protocol v3 (Noise)** with a
-    [provisioned PSK](#provisioned-psk), falling back to the legacy handshake on older hubs.
+    same HiveMind protocol to the same hivemind-core instance, including **protocol v3 (Noise)** with a
+    [provisioned PSK](#provisioned-psk), falling back to the legacy handshake on older hivemind-core versions.
 
 ---
 
@@ -28,17 +34,17 @@ On protocol **v3** the session is protected by a **Noise** handshake
 (`Noise_XXpsk2_25519_ChaChaPoly_SHA256`), which mixes in a 32-byte pre-shared key
 derived from your password as `argon2id(password, SHA-256(node_id))`. argon2id is far
 too heavy to run on a microcontroller, so constrained clients never derive it
-on-device — you **pre-compute** it on the hub and flash the result:
+on-device — you **pre-compute** it on hivemind-core and flash the result:
 
 ```bash
-hivemind-core derive-psk --password "your-password" --node-id "<hub-node-id>"
+hivemind-core derive-psk --password "your-password" --node-id "<hivemind-core-node-id>"
 ```
 
 The printed hex string is the same PSK a full peer would derive, so the device
 interoperates with no server-side distinction — and the device never stores the
 password itself. Provision it as `noise_psk_hex` (ESP32) or the `psk=` argument
-(MicroPython). If the hub does not advertise v3 (or no PSK is set), the client falls
-back to the legacy password handshake automatically. Optionally pin the hub's static
+(MicroPython). If hivemind-core does not advertise v3 (or no PSK is set), the client falls
+back to the legacy password handshake automatically. Optionally pin hivemind-core's static
 X25519 key to enable the lighter `Noise_KKpsk0` pattern.
 
 ---
@@ -57,9 +63,9 @@ ESP32-C3. Requires **ESP-IDF 5.0+** on the build host.
 
 - On-device **microphone** (INMP441 I2S mic in the mic example).
 - On the **ESP32-S3 Voice PE** build: on-device **VAD** and an optional **wakeword**
-  (ESP-SR **WakeNet9**). On a plain ESP32 the mic streams audio and the hub does the
+  (ESP-SR **WakeNet9**). On a plain ESP32 the mic streams audio and hivemind-core does the
   rest.
-- **STT and TTS are off-device** — the hub provides them.
+- **STT and TTS are off-device** — hivemind-core provides them.
 
 ??? note "Advanced: audio transport modes"
     The component can ship audio three ways, and the example lets you pick per axis:
@@ -70,9 +76,9 @@ ESP32-C3. Requires **ESP-IDF 5.0+** on the build host.
     - **HiveMind base64** — batches a WAV over the bus via `recognizer_loop:b64_transcribe`,
       with TTS via `speak:b64_audio`.
     - **OVOS HTTP** — POST/GET against a standalone OVOS STT/TTS HTTP server, bypassing
-      the hub for speech.
+      hivemind-core for speech.
 
-    For the two HiveMind modes the hub needs
+    For the two HiveMind modes hivemind-core needs
     [`hivemind-audio-binary-protocol`](../server/audio-binary-protocol.md). Encryption
     is AES-256-GCM (hardware-accelerated on the ESP32) or ChaCha20-Poly1305, with the
     session key derived from your password via PBKDF2-HMAC-SHA256.
@@ -82,11 +88,11 @@ ESP32-C3. Requires **ESP-IDF 5.0+** on the build host.
 ```bash
 # from an example directory, e.g. examples/mic_satellite
 idf.py set-target esp32s3        # or esp32, esp32c3
-idf.py menuconfig                # set Wi-Fi SSID/password and the hub host/key/password
+idf.py menuconfig                # set Wi-Fi SSID/password and the server host/key/password
 idf.py build flash monitor
 ```
 
-Register the device on the hub first, as with any satellite:
+Register the device on hivemind-core first, as with any satellite:
 
 ```bash
 hivemind-core add-client --name esp32 \
@@ -118,7 +124,7 @@ write Python than C.
 
 The device keeps a tiny footprint by running no OVOS on-device: it performs the full
 HiveMind handshake and encrypted messaging, then streams **PCM audio over the binary
-channel** (via the `machine.I2S` peripheral in the mic example) to the hub, which does
+channel** (via the `machine.I2S` peripheral in the mic example) to hivemind-core, which does
 the speech work. On protocol **v3** the session is a **Noise** handshake using a
 [provisioned PSK](#provisioned-psk); on the legacy path, encryption is AES-256-GCM or
 ChaCha20-Poly1305 with PBKDF2-HMAC-SHA256 key derivation — byte-for-byte compatible

--- a/docs/satellites/voice-relay.md
+++ b/docs/satellites/voice-relay.md
@@ -1,10 +1,14 @@
 # Voice Relay
 
-Runs microphone, VAD, and wakeword detection locally. Forwards audio to the hub after the wakeword triggers — STT and TTS synthesis run on the hub.
+**Voice-relay runs microphone, VAD, and wakeword detection locally, then forwards audio to hivemind-core only after the wakeword triggers.** STT and TTS synthesis run on hivemind-core.
 
-**What runs locally**: Microphone + VAD + Wakeword
+!!! abstract "In a nutshell"
+    - **Runs locally**: microphone + VAD + wakeword.
+    - **hivemind-core provides**: STT and TTS — requires `hivemind-audio-binary-protocol` on hivemind-core.
+    - Audio leaves the device only after wakeword activation, saving bandwidth and improving privacy over the [mic satellite](mic-satellite.md).
+    - STT/TTS are centrally governed by the hivemind-core operator — the "HiveMind as a service" model — so a relay cannot pick its own speech engines.
 
-**What the hub provides**: STT, TTS (requires `hivemind-audio-binary-protocol` on the hub)
+---
 
 ## When to use it
 
@@ -13,11 +17,15 @@ Runs microphone, VAD, and wakeword detection locally. Forwards audio to the hub 
 - Scenarios where audio should not leave the device until activation (latency + privacy)
 - Multi-user or at-scale service deployments
 
+---
+
 ## The service model
 
-Voice-relay's architecture has a specific meaning: STT and TTS run inside the hive (the `hivemind-audio-binary-protocol` plugin on `hivemind-core`) and are gated by the same access-key authentication as all other HiveMind messages. The hub operator chooses the STT engine, TTS engine, and voice. A relay satellite cannot override them.
+Voice-relay's architecture has a specific meaning: STT and TTS run inside the hive (the `hivemind-audio-binary-protocol` plugin on `hivemind-core`) and are gated by the same access-key authentication as all other HiveMind messages. The hivemind-core operator chooses the STT engine, TTS engine, and voice. A relay satellite cannot override them.
 
 This is the difference from voice-sat: a voice-sat can point at any STT/TTS plugin it likes. A relay cannot.
+
+---
 
 ## Install
 
@@ -25,17 +33,21 @@ This is the difference from voice-sat: a voice-sat can point at any STT/TTS plug
 pip install HiveMind-voice-relay
 ```
 
-## Hub requirements
+---
 
-The hub must have `hivemind-audio-binary-protocol` installed and configured. Alternatively, run `hivemind-core` together with `ovos-audio` and `ovos-dinkum-listener` to provide equivalent capabilities.
+## Server requirements
+
+hivemind-core must have `hivemind-audio-binary-protocol` installed and configured. Alternatively, run `hivemind-core` together with `ovos-audio` and `ovos-dinkum-listener` to provide equivalent capabilities.
 
 See [Audio Binary Protocol](../server/audio-binary-protocol.md).
 
+---
+
 ## Quickstart
 
-> **Pre-flight:** wakeword runs locally, but after activation this satellite sends audio to the hub, so **the hub MUST have the [Audio Binary Protocol](../server/audio-binary-protocol.md) configured** — it provides STT and TTS. Without it the satellite connects but its audio is silently dropped, with no error.
+> **Pre-flight:** wakeword runs locally, but after activation this satellite sends audio to hivemind-core, so **hivemind-core MUST have the [Audio Binary Protocol](../server/audio-binary-protocol.md) configured** — it provides STT and TTS. Without it the satellite connects but its audio is silently dropped, with no error.
 
-**1. On the hub** — register a client:
+**1. On hivemind-core** — register a client:
 
 ```bash
 hivemind-core add-client --name my-voice-relay
@@ -47,7 +59,7 @@ hivemind-core add-client --name my-voice-relay
 hivemind-client set-identity \
   --key <access_key> \
   --password <password> \
-  --host <hub_host>
+  --host <server_host>
 ```
 
 **3. Run:**
@@ -57,6 +69,8 @@ hivemind-voice-relay
 ```
 
 **4. Say your wake word.** Default is `hey mycroft` (configured in `~/.config/mycroft/mycroft.conf`).
+
+---
 
 ## CLI flags
 
@@ -72,6 +86,8 @@ Options:
   --siteid TEXT    Location identifier for message context
 ```
 
+---
+
 ## Configuration
 
 voice-relay reads `~/.config/mycroft/mycroft.conf`.
@@ -85,12 +101,14 @@ voice-relay reads `~/.config/mycroft/mycroft.conf`.
 | Media playback | various | No |
 | PHAL | `PHAL.ovos-phal-...` | No |
 
+---
+
 ## How audio flows
 
 ```
 [Microphone] → [VAD] → [Wakeword detector]
                               ↓ (after activation)
-                    audio chunk → [HiveMind Hub]
+                    audio chunk → [hivemind-core]
                                        ↓
                              [hivemind-audio-binary-protocol]
                                        ↓
@@ -103,9 +121,13 @@ voice-relay reads `~/.config/mycroft/mycroft.conf`.
 
 After the wakeword triggers, audio is sent as base64-encoded audio via `recognizer_loop:b64_transcribe`. TTS audio comes back via `speak:b64_audio`.
 
+---
+
 ## Next
 
-Set up the hub side: [Audio Binary Protocol](../server/audio-binary-protocol.md).
+Set up the server side: [Audio Binary Protocol](../server/audio-binary-protocol.md).
+
+---
 
 ## Source
 
@@ -113,4 +135,4 @@ Validated against the HiveMind source:
 
 - [`hivemind_voice_relay/service.py`](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/HEAD/hivemind_voice_relay/service.py) — base64-over-bus transport: STT via `recognizer_loop:b64_transcribe`, TTS via `speak:b64_audio`
 - [`hivemind_voice_relay/__main__.py`](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/HEAD/hivemind_voice_relay/__main__.py) — CLI flags (`--host --key --password --port --selfsigned --siteid`)
-- [`docs/architecture.md`](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/HEAD/docs/architecture.md) — local mic + VAD + wakeword, hub-owned STT/TTS
+- [`docs/architecture.md`](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/HEAD/docs/architecture.md) — local mic + VAD + wakeword, server-owned STT/TTS

--- a/docs/satellites/voice-sat.md
+++ b/docs/satellites/voice-sat.md
@@ -1,16 +1,24 @@
 # Voice Satellite
 
-The full-stack OVOS voice satellite. Microphone, VAD, and wakeword run on this device, and the STT/TTS plugins are configured here rather than on the hub. Only the transcribed text utterance is sent to the hub — never audio. Responses arrive as text and are spoken locally.
+**The voice satellite is the full-stack OVOS satellite: microphone, VAD, wakeword, and the STT/TTS plugins all run on the device.** Only the transcribed text utterance is sent to hivemind-core — never audio. Responses arrive as text and are spoken locally.
+
+!!! abstract "In a nutshell"
+    - **Runs locally**: microphone, VAD, wakeword, plus STT and TTS.
+    - **hivemind-core provides**: skills, intents, and reasoning — no `hivemind-audio-binary-protocol` needed.
+    - Sends only text utterances, so audio never reaches hivemind-core and STT/TTS are chosen independently of any hivemind-core config.
+    - The shipped default plugins (`ovos-stt-plugin-server` / `ovos-tts-plugin-server`) are remote HTTP services; swap in local plugins for fully on-device, offline operation.
 
 > **Note**: STT and TTS are chosen on the satellite, but the *shipped defaults*
 > (`ovos-stt-plugin-server` / `ovos-tts-plugin-server`) are remote HTTP services
-> pointed at `*.openvoiceos.org`. Audio stays off the hub, but with the defaults it
+> pointed at `*.openvoiceos.org`. Audio stays off hivemind-core, but with the defaults it
 > still leaves the device for transcription. For true on-device/offline operation,
 > swap in local STT/TTS plugins (see [Configuration](#configuration)).
 
 **What runs locally**: Microphone + VAD + Wakeword (+ STT + TTS if local plugins are configured)
 
-**What the hub provides**: Skills, intents, reasoning
+**What hivemind-core provides**: Skills, intents, reasoning
+
+---
 
 ## When to use it
 
@@ -21,6 +29,8 @@ The full-stack OVOS voice satellite. Microphone, VAD, and wakeword run on this d
 - Low-latency interaction (no round-trip for audio)
 - Fully offline operation after initial model downloads — again, only with local
   STT/TTS plugins in place of the remote-server defaults
+
+---
 
 ## Install
 
@@ -34,9 +44,11 @@ pip install HiveMind-voice-sat[linux]
 pip install HiveMind-voice-sat[mac]
 ```
 
+---
+
 ## Quickstart
 
-**1. On the hub** — register a client:
+**1. On hivemind-core** — register a client:
 
 ```bash
 hivemind-core add-client --name my-voice-sat
@@ -45,10 +57,10 @@ hivemind-core add-client --name my-voice-sat
 **2. On the satellite** — run it:
 
 ```bash
-hivemind-voice-sat --host <hub_host> --key <access_key> --password <password>
+hivemind-voice-sat --host <server_host> --key <access_key> --password <password>
 ```
 
-Say your wakeword. The satellite transcribes locally and sends the utterance text to the hub.
+Say your wakeword. The satellite transcribes locally and sends the utterance text to hivemind-core.
 
 !!! tip "Pairing by sound (no `--password`)"
     If you start voice-sat **without** a `--password` (and none is stored in the
@@ -58,6 +70,8 @@ Say your wakeword. The satellite transcribes locally and sends the utterance tex
     audio "chirp" played near the device. Once it receives and stores the credentials,
     it connects automatically. This lets you pair a headless device by playing the
     pairing tone at it instead of typing a password.
+
+---
 
 ## CLI reference
 
@@ -74,6 +88,8 @@ Options:
 ```
 
 All flags fall back to the identity file written by `hivemind-client set-identity`.
+
+---
 
 ## Configuration
 
@@ -117,15 +133,21 @@ All plugin slots are swappable via [ovos-plugin-manager](https://github.com/Open
 | Audio/Dialog transformers | various | No |
 | PHAL | `PHAL.ovos-phal-...` | No |
 
+---
+
 ## How it differs from other satellites
 
-Unlike mic-satellite and voice-relay, voice-sat sends **text utterances** to the hub — no audio reaches the hub. The hub only needs to run skills and return text responses. It does not need `hivemind-audio-binary-protocol`. (With the default remote STT/TTS plugins, audio is still sent to the configured speech server for transcription; use local plugins to keep all audio on-device.)
+Unlike mic-satellite and voice-relay, voice-sat sends **text utterances** to hivemind-core — no audio reaches hivemind-core. hivemind-core only needs to run skills and return text responses. It does not need `hivemind-audio-binary-protocol`. (With the default remote STT/TTS plugins, audio is still sent to the configured speech server for transcription; use local plugins to keep all audio on-device.)
 
-You also choose your own STT and TTS plugins, independent of any hub configuration.
+You also choose your own STT and TTS plugins, independent of any hivemind-core configuration.
+
+---
 
 ## Next
 
-Give your hub something to answer with: set up the [OVOS Skills Hub](../server/ovos-hub.md).
+Give hivemind-core something to answer with: set up an [OVOS Skills backend](../server/ovos-hub.md).
+
+---
 
 ## Source
 

--- a/docs/satellites/voice-sat.md
+++ b/docs/satellites/voice-sat.md
@@ -145,7 +145,7 @@ You also choose your own STT and TTS plugins, independent of any hivemind-core c
 
 ## Next
 
-Give hivemind-core something to answer with: set up an [OVOS Skills backend](../server/ovos-hub.md).
+Give hivemind-core something to answer with: set up an [OVOS Skills backend](../server/ovos-server.md).
 
 ---
 

--- a/docs/satellites/webspeech.md
+++ b/docs/satellites/webspeech.md
@@ -42,10 +42,16 @@ reply.
     `http://localhost`).
 
 ??? note "Advanced: crypto and VAD details"
-    - **Encryption** is HiveMind Protocol V1: a password handshake using
-      **PBKDF2-HMAC-SHA256** key derivation plus **AES-GCM** session encryption, all
-      over the browser's native **Web Crypto** API. The **Password** field in the form
-      is the password from `hivemind-core add-client` — it drives the key derivation.
+    - **Encryption** defaults to the **Protocol v3 Noise handshake** with full parity
+      to hivemind-core: the browser negotiates the default
+      `Noise_XXpsk2_25519_ChaChaPoly_SHA256` suite and derives the PSK as
+      `argon2id(password, SHA-256(node_id))` **in-browser**, pairing the native
+      **Web Crypto** API with the pure-JS `@noble/ciphers` + `@noble/hashes` bundle.
+      The **Password** field in the form is the password from
+      `hivemind-core add-client` — a password alone is enough, with no server-side
+      configuration and no provisioned key. It falls back to the legacy V1 handshake
+      (PBKDF2-HMAC-SHA256 + AES-GCM) against older hubs, or when a minimal bundle
+      ships without `@noble`.
     - **No wakeword.** Capture is push-to-talk, gated by a **Start VAD** / **Stop VAD**
       toggle. Voice activity detection uses the **Silero VAD** model run in the browser
       via **onnxruntime-web** (`@ricky0123/vad-web`), loaded from a CDN — so the page
@@ -84,5 +90,5 @@ side per the requirements above.
 Validated against the HiveMind source:
 
 - [`docs/configuration.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/docs/configuration.md) — hub requirements, the TLS/mixed-content rule, the credential form
-- [`README.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/README.md) — V1 crypto (PBKDF2-HMAC-SHA256 + AES-GCM), Silero VAD via onnxruntime-web, `recognizer_loop:b64_audio` transport
+- [`README.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/README.md) — v3 Noise crypto (ChaChaPoly + in-browser argon2id PSK) with V1 (PBKDF2 + AES-GCM) fallback, Silero VAD via onnxruntime-web, `recognizer_loop:b64_audio` transport
 - [`readme.md`](https://github.com/JarbasHiveMind/HiveMind-js/blob/HEAD/readme.md) — the JavaScript client library this page is built on

--- a/docs/satellites/webspeech.md
+++ b/docs/satellites/webspeech.md
@@ -1,10 +1,14 @@
 # WebSpeech Browser Satellite
 
-A JavaScript-based satellite that runs in any modern web browser. Captures microphone audio in the browser and streams it to the hub for processing.
+**The WebSpeech satellite is a JavaScript client that runs in any modern web browser**, capturing microphone audio in the browser and streaming it to hivemind-core for processing.
 
-**What runs locally**: Browser microphone + VAD (JavaScript)
+!!! abstract "In a nutshell"
+    - **Runs locally**: browser microphone + VAD (JavaScript, Silero via onnxruntime-web).
+    - **hivemind-core provides**: STT, TTS, skills, and intents.
+    - Ships captured audio as base64 over the bus (`recognizer_loop:b64_audio`), so hivemind-core needs `ovos-dinkum-listener >= 0.0.3a19` and `hivemind-core allow-msg "recognizer_loop:b64_audio"` — not the binary `RAW_AUDIO` protocol.
+    - Encryption defaults to the Noise v3 handshake with full parity to hivemind-core, deriving the PSK from the password in-browser; a password alone is enough.
 
-**What the hub provides**: STT, TTS, skills, intents
+---
 
 ## When to use it
 
@@ -12,11 +16,13 @@ A JavaScript-based satellite that runs in any modern web browser. Captures micro
 - Temporary client access from any device with a browser
 - Users already in a browser context
 
+---
+
 ## Requirements
 
 This browser client ships its captured audio as **base64 over the bus** (the
-`recognizer_loop:b64_audio` message), not as the binary `RAW_AUDIO` protocol. So the
-hub does **not** need `hivemind-audio-binary-protocol`. Instead the hub must:
+`recognizer_loop:b64_audio` message), not as the binary `RAW_AUDIO` protocol. So
+hivemind-core does **not** need `hivemind-audio-binary-protocol`. Instead hivemind-core must:
 
 1. Run a listener new enough to decode that message — `ovos-dinkum-listener >= 0.0.3a19`.
 2. Be told to accept the message:
@@ -35,9 +41,10 @@ reply.
       a plain `ws://` target is blocked.
     - A plain **`ws://`** WebSocket is only allowed to **`127.0.0.1`** / `localhost`.
 
-    So for **local** testing, serve the page on `http://localhost` and connect to a hub
-    on `ws://127.0.0.1`. To reach a **remote** hub from an `https://` page (such as the
-    hosted demo), the hub's WebSocket must terminate TLS — use `wss://`. Microphone
+    So for **local** testing, serve the page on `http://localhost` and connect to a
+    hivemind-core instance on `ws://127.0.0.1`. To reach a **remote** hivemind-core from
+    an `https://` page (such as the hosted demo), its WebSocket must terminate TLS — use
+    `wss://`. Microphone
     access (`getUserMedia`) also requires a secure context (`https://` or
     `http://localhost`).
 
@@ -50,22 +57,28 @@ reply.
       The **Password** field in the form is the password from
       `hivemind-core add-client` — a password alone is enough, with no server-side
       configuration and no provisioned key. It falls back to the legacy V1 handshake
-      (PBKDF2-HMAC-SHA256 + AES-GCM) against older hubs, or when a minimal bundle
+      (PBKDF2-HMAC-SHA256 + AES-GCM) against older hivemind-core versions, or when a minimal bundle
       ships without `@noble`.
     - **No wakeword.** Capture is push-to-talk, gated by a **Start VAD** / **Stop VAD**
       toggle. Voice activity detection uses the **Silero VAD** model run in the browser
       via **onnxruntime-web** (`@ricky0123/vad-web`), loaded from a CDN — so the page
       needs network access on first load.
 
+---
+
 ## Installation
 
 No installation required on the client side. Include the [HiveMind.js](https://github.com/JarbasHiveMind/HiveMind-js) library in your HTML.
+
+---
 
 ## Resources
 
 - [hivemind-webspeech](https://github.com/JarbasHiveMind/hivemind-webspeech) — reference implementation
 - [HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js) — JavaScript client library
 - [hivemind-flask-chatroom](https://github.com/JarbasHiveMind/hivemind-flask-chatroom) — Flask template for a browser-based chatroom
+
+---
 
 ## Limitations
 
@@ -74,21 +87,27 @@ No installation required on the client side. Include the [HiveMind.js](https://g
 - Microphone access requires user permission (browser security model)
 - No wakeword — capture is VAD-gated push-to-talk via a VAD toggle button
 
+---
+
 ## See also
 
 For a text-only browser experience, [hivemind-flask-chatroom](https://github.com/JarbasHiveMind/hivemind-flask-chatroom)
 is a Flask web app (default port `8985`, no audio) that fans one server-side credential
 out to many browser visitors as a shared chatroom.
 
+---
+
 ## Next
 
-New to HiveMind? Start with the [Quick Start](../quickstart.md), then prepare the hub
+New to HiveMind? Start with the [Quick Start](../quickstart.md), then prepare the server
 side per the requirements above.
+
+---
 
 ## Source
 
 Validated against the HiveMind source:
 
-- [`docs/configuration.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/docs/configuration.md) — hub requirements, the TLS/mixed-content rule, the credential form
+- [`docs/configuration.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/docs/configuration.md) — server requirements, the TLS/mixed-content rule, the credential form
 - [`README.md`](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/HEAD/README.md) — v3 Noise crypto (ChaChaPoly + in-browser argon2id PSK) with V1 (PBKDF2 + AES-GCM) fallback, Silero VAD via onnxruntime-web, `recognizer_loop:b64_audio` transport
 - [`readme.md`](https://github.com/JarbasHiveMind/HiveMind-js/blob/HEAD/readme.md) — the JavaScript client library this page is built on

--- a/docs/server/a2a-hub.md
+++ b/docs/server/a2a-hub.md
@@ -1,10 +1,15 @@
-# A2A Hub
+# A2A Server
 
-An "A2A hub" is a regular `hivemind-core` server whose **agent protocol** is the
-[hivemind-a2a-agent-plugin](https://github.com/JarbasHiveMind/hivemind-a2a-agent-plugin).
-Instead of routing utterances into a full OVOS skills stack, the hub forwards
+**An A2A server is a regular `hivemind-core` server whose agent protocol is the
+[hivemind-a2a-agent-plugin](https://github.com/JarbasHiveMind/hivemind-a2a-agent-plugin).**
+Instead of routing utterances into a full OVOS skills stack, it forwards
 natural-language queries to an external **A2A (Agent-to-Agent)** server and streams the
 answer back — no `ovos-core` required.
+
+!!! abstract "In a nutshell"
+    - Swaps the `agent_protocol` for `hivemind-a2a-agent-plugin`, forwarding queries to any Google A2A-compliant server.
+    - Only `agent_url` is required; `auth_header`, `timeout`, and `streaming` are optional.
+    - The HiveMind `session_id` maps 1-to-1 to the A2A `sessionId`, so multi-turn context lives on the A2A server.
 
 [A2A](https://google.github.io/A2A/) is Google's open protocol for agent
 interoperability. An A2A server publishes an **agent card** at
@@ -14,9 +19,11 @@ requests as JSON-RPC 2.0 — either a blocking `tasks/send` or a streaming
 CrewAI, a custom FastAPI service, …) works behind this plugin.
 
 Satellites built for `hivemind-core` (text-based ones like HiveMind-cli, voice-sat, or
-bridges) work against an A2A hub. Satellites that depend on the audio binary protocol
-(`hivemind-audio-binary-protocol`) do **not** apply here — like a persona hub, an A2A
-hub exposes a text/query agent, not server-side audio processing.
+bridges) work against an A2A server. Satellites that depend on the audio binary protocol
+(`hivemind-audio-binary-protocol`) do **not** apply here — like a persona server, an A2A
+server exposes a text/query agent, not server-side audio processing.
+
+---
 
 ## Install
 
@@ -29,6 +36,8 @@ The plugin registers itself under the `hivemind.agent.protocol` entry-point grou
 
 You also need a running A2A server to point it at. Any compliant A2A server works; the
 plugin only owns the outbound HTTP connection to it.
+
+---
 
 ## Configure hivemind-core
 
@@ -58,7 +67,7 @@ Only `agent_url` is required. The configuration keys are:
 | `timeout`     | `60.0`  | HTTP timeout in seconds.                                 |
 | `streaming`   | `false` | Prefer `tasks/sendSubscribe` (SSE) when `true`.          |
 
-With `streaming` left at `false` the hub submits a blocking `tasks/send` and returns the
+With `streaming` left at `false` `hivemind-core` submits a blocking `tasks/send` and returns the
 final text. Set it to `true` to use `tasks/sendSubscribe` and stream chunks back to the
 satellite as the agent produces them, provided the A2A server advertises streaming.
 
@@ -88,14 +97,18 @@ conversation state.
     When both are present, explicit values passed in the `agent_protocol` block win
     over the OVOS-config fallback.
 
+---
+
 ## Start the server
 
 ```bash
 hivemind-core listen
 ```
 
-Satellites connecting to this hub now receive answers from the A2A agent — streamed
+Satellites connecting to this server now receive answers from the A2A agent — streamed
 chunk by chunk when `streaming` is enabled, or as a single response otherwise.
+
+---
 
 ## Managing clients
 
@@ -113,14 +126,18 @@ hivemind-core list-clients
 hivemind-core delete-client 2
 ```
 
-See [OVOS Skills Hub](ovos-hub.md#managing-clients) for the full client workflow.
+See [OVOS Skills Server](ovos-hub.md#managing-clients) for the full client workflow.
+
+---
 
 ## Next
 
 - [Operations](operations.md) — TLS, reverse proxy, systemd, observability, and scaling.
-- [Persona Hub](persona-hub.md) — answer queries from a local LLM / solver chain instead
+- [Persona Server](persona-hub.md) — answer queries from a local LLM / solver chain instead
   of an external A2A server.
 - [Database Backends](../concepts/databases.md) — where client and permission state lives.
+
+---
 
 ## Source
 

--- a/docs/server/a2a-server.md
+++ b/docs/server/a2a-server.md
@@ -126,14 +126,14 @@ hivemind-core list-clients
 hivemind-core delete-client 2
 ```
 
-See [OVOS Skills Server](ovos-hub.md#managing-clients) for the full client workflow.
+See [OVOS Skills Server](ovos-server.md#managing-clients) for the full client workflow.
 
 ---
 
 ## Next
 
 - [Operations](operations.md) — TLS, reverse proxy, systemd, observability, and scaling.
-- [Persona Server](persona-hub.md) — answer queries from a local LLM / solver chain instead
+- [Persona Server](persona-server.md) — answer queries from a local LLM / solver chain instead
   of an external A2A server.
 - [Database Backends](../concepts/databases.md) — where client and permission state lives.
 

--- a/docs/server/admin-panel.md
+++ b/docs/server/admin-panel.md
@@ -18,7 +18,7 @@ The **HiveMind Admin Panel** is a web browser dashboard for running and administ
 ## What it is
 
 `hivemind-admin-panel` is a standalone, optional package (a FastAPI backend plus a
-single-page web UI) that administers [`hivemind-core`](ovos-hub.md). From the browser you
+single-page web UI) that administers [`hivemind-core`](ovos-server.md). From the browser you
 can:
 
 - **Clients & access keys** — create, list, update, and revoke satellite credentials,
@@ -123,7 +123,7 @@ has TLS — and stays red until the critical items clear.
 ## See also
 
 - [Quick Start](../quickstart.md) — the CLI flow; the panel is the easier alternative to it.
-- [OVOS Skills Server](ovos-hub.md) — what the in-process `hivemind-core` actually runs.
+- [OVOS Skills Server](ovos-server.md) — what the in-process `hivemind-core` actually runs.
 - [Security](../concepts/security.md) — access keys, certificates, and permissions.
 
 ---

--- a/docs/server/admin-panel.md
+++ b/docs/server/admin-panel.md
@@ -1,9 +1,14 @@
 # Admin Panel
 
-The **HiveMind Admin Panel** is a web browser dashboard for running and administering a
-hub. It is the **easiest** way to stand up and manage a HiveMind: one command starts a
-hub *and* opens a UI to administer it — no editing `server.json` by hand and no separate
+The **HiveMind Admin Panel** is a web browser dashboard for running and administering
+`hivemind-core`. It is the **easiest** way to stand up and manage a HiveMind: one command starts
+`hivemind-core` *and* opens a UI to administer it — no editing `server.json` by hand and no separate
 `hivemind-core` process to babysit.
+
+!!! abstract "In a nutshell"
+    - One command starts `hivemind-core` in-process and serves a web UI to administer it.
+    - Manage clients, per-client ACLs, personas, plugins, and config from the browser, with QR pairing and an ACL-enforcing test chat.
+    - A privileged control plane: authenticated over HTTP Basic, bound to `127.0.0.1` by default, with a forced first-run password change.
 
 !!! tip "New here? Start with the panel"
     If the CLI flow in the [Quick Start](../quickstart.md) feels like a lot, use this
@@ -21,7 +26,7 @@ can:
 - **Per-client ACLs** — allow message types, blacklist skills/intents, toggle the
   admin / escalate / propagate flags, and apply reusable ACL templates.
 - **Test Chat** — an in-browser chat that impersonates any client and talks through the
-  hub to the real agent, **enforcing that client's real ACLs** — so you test the actual
+  server to the real agent, **enforcing that client's real ACLs** — so you test the actual
   permission path, not a bypass.
 - **Personas & agents** — manage personas and the agent backend, with a memory-aware
   test chat and pre-activation validation.
@@ -29,23 +34,27 @@ can:
   and save named **plugin presets** (`{module, config}` for STT/TTS/WW/VAD/agent/network).
 - **Config safety** — `server.json` is **snapshotted before every change**; diff and
   one-click **revert** from the Operations page.
-- **Live monitoring** — SSE-streamed metrics, the hub log tail, an audit log, and an
-  interactive **topology graph** (hub ↔ satellites with online status).
+- **Live monitoring** — SSE-streamed metrics, the `hivemind-core` log tail, an audit log, and an
+  interactive **topology graph** (`hivemind-core` ↔ satellites with online status).
 - **Security self-check**, **backup/restore**, **self-signed TLS cert generation**, and
   one-click provisioning of the **Matrix / Twitch / Mattermost / DeltaChat / HackChat**
   chat bridges.
 
+---
+
 ## The key idea: one launcher
 
-!!! note "The panel *is* the hub launcher"
+!!! note "The panel *is* the `hivemind-core` launcher"
     By default the panel starts `hivemind-core` **in-process** (in a daemon thread) and
-    serves the admin UI on top of it. So a single command gives you a running hub
+    serves the admin UI on top of it. So a single command gives you a running `hivemind-core`
     **plus** a place to administer it — you do **not** run `hivemind-core` separately.
 
     Pass `--no-core` to serve the panel against on-disk config/database only (useful
     when a `hivemind-core` is managed elsewhere on the host, or to provision clients
     without touching a live service). In that mode the live-connection views degrade to
     placeholder data, but everything backed by the database and config still works.
+
+---
 
 ## Install & run
 
@@ -60,16 +69,16 @@ hivemind-admin-panel --host 127.0.0.1 --port 8100
 ```
 
 Open <http://127.0.0.1:8100>. You will be prompted for HTTP Basic credentials (see
-below). The hub's own transports (WebSocket on `:5678`, etc.) are configured in
+below). The `hivemind-core` transports (WebSocket on `:5678`, etc.) are configured in
 `server.json`, independently of the panel's `--host` / `--port`.
 
 | Flag | Default | Meaning |
 |---|---|---|
 | `--host` | `127.0.0.1` | bind address for the panel UI |
 | `--port` | `8100` | port for the panel UI |
-| `--no-core` | off | serve the panel only; don't start an in-process hub |
+| `--no-core` | off | serve the panel only; don't start an in-process `hivemind-core` |
 | `--reload` | off | dev auto-reload (implies `--no-core`) |
-| `--log-level` | `INFO` | log level for the in-process hub |
+| `--log-level` | `INFO` | log level for the in-process `hivemind-core` |
 
 ### Docker
 
@@ -81,9 +90,11 @@ docker compose up --build
 # open http://127.0.0.1:8100  (edit docker/server.json to set admin_pass first)
 ```
 
+---
+
 ## Configuration & security
 
-The panel reads the **same** `~/.config/hivemind-core/server.json` that the hub uses.
+The panel reads the **same** `~/.config/hivemind-core/server.json` that `hivemind-core` uses.
 Authentication is HTTP Basic (or a bearer token from `POST /auth/login`) on every
 endpoint, with credentials in the `admin_user` / `admin_pass` keys (both default
 `admin`). Comparison is timing-safe and new passwords are stored hashed (PBKDF2).
@@ -91,13 +102,13 @@ endpoint, with credentials in the `admin_user` / `admin_pass` keys (both default
 On your **first login with the default password, the panel forces a password change**
 (a modal that blocks the whole UI until you set a new one). A dashboard **security
 self-check** then flags, in red/yellow/green, whether the password is still default,
-whether the panel is bound to a non-loopback address, and whether the hub's WebSocket
+whether the panel is bound to a non-loopback address, and whether the `hivemind-core` WebSocket
 has TLS — and stays red until the critical items clear.
 
 !!! danger "Never expose the default credentials to a network"
     The panel is a **privileged control plane** — through it an authenticated caller can
     `pip install` packages into the server's interpreter, migrate or clear databases,
-    mint client credentials, and restart the hub. Treat access as equivalent to shell
+    mint client credentials, and restart `hivemind-core`. Treat access as equivalent to shell
     access on the host.
 
     - Keep the bind on `127.0.0.1` (the default) unless it sits behind a trusted,
@@ -107,11 +118,15 @@ has TLS — and stays red until the critical items clear.
     - `--host 0.0.0.0` and the Docker image bind all interfaces — only do that behind a
       proxy / firewall.
 
+---
+
 ## See also
 
 - [Quick Start](../quickstart.md) — the CLI flow; the panel is the easier alternative to it.
-- [OVOS Skills Hub](ovos-hub.md) — what the in-process hub actually runs.
+- [OVOS Skills Server](ovos-hub.md) — what the in-process `hivemind-core` actually runs.
 - [Security](../concepts/security.md) — access keys, certificates, and permissions.
+
+---
 
 ## Source
 

--- a/docs/server/audio-binary-protocol.md
+++ b/docs/server/audio-binary-protocol.md
@@ -1,14 +1,23 @@
 # Audio Binary Protocol
 
-`hivemind-audio-binary-protocol` is a binary data handler plugin for `hivemind-core`. It enables the hub to receive audio streams from satellites, run wakeword detection, STT, and TTS synthesis, and return synthesized audio to the satellite.
+**`hivemind-audio-binary-protocol` is a binary data handler plugin for `hivemind-core`.** It enables `hivemind-core` to receive audio streams from satellites, run wakeword detection, STT, and TTS synthesis, and return synthesized audio to the satellite.
+
+!!! abstract "In a nutshell"
+    - A `hivemind.binary.protocol` plugin that lets `hivemind-core` process raw audio; required for mic-satellite and voice-relay.
+    - `hivemind-core` owns the wakeword/STT/TTS/VAD plugins centrally — a satellite cannot choose the engine or voice.
+    - Access is gated by the client's access key and permissions; there is no open audio endpoint.
 
 Without this plugin, `hivemind-core` cannot process audio. It is required for mic-satellite and voice-relay.
+
+---
 
 ## Install
 
 ```bash
 pip install hivemind-audio-binary-protocol
 ```
+
+---
 
 ## Configuration
 
@@ -55,10 +64,12 @@ pip install ovos-stt-plugin-server     # or any other STT plugin
 pip install ovos-tts-plugin-server     # or any other TTS plugin
 ```
 
+---
+
 ## Audio flow
 
 ```
-[mic-satellite]                     [HiveMind Hub]
+[mic-satellite]                     [hivemind-core]
   Mic + VAD                         AudioBinaryProtocol
      │                                    │
      │── BINARY (RAW_AUDIO) ─────────────→│
@@ -74,6 +85,8 @@ pip install ovos-tts-plugin-server     # or any other TTS plugin
   Playback
 ```
 
+---
+
 ## Binary payload types
 
 | Value | Name | Description |
@@ -81,15 +94,21 @@ pip install ovos-tts-plugin-server     # or any other TTS plugin
 | 1 | `RAW_AUDIO` | Continuous microphone stream (VAD-gated) |
 | 4 | `STT_AUDIO_TRANSCRIBE` | Full audio sentence — return transcript only |
 | 5 | `STT_AUDIO_HANDLE` | Full audio sentence — transcribe and handle intent |
-| 6 | `TTS_AUDIO` | Synthesized speech audio (hub → satellite) |
+| 6 | `TTS_AUDIO` | Synthesized speech audio (server → satellite) |
+
+---
 
 ## The service model
 
-STT and TTS running on the hub via this plugin are authenticated by the same access-key mechanism as all other HiveMind messages. A satellite cannot choose the engine or voice — the hub operator configures them centrally. This is intentional: the hive owns its speech services, just as it owns its skills.
+STT and TTS running on `hivemind-core` via this plugin are authenticated by the same access-key mechanism as all other HiveMind messages. A satellite cannot choose the engine or voice — the server operator configures them centrally. This is intentional: the hive owns its speech services, just as it owns its skills.
+
+---
 
 ## Security note
 
 Running STT/TTS through the audio binary protocol requires the satellite to have valid HiveMind credentials. There is no open audio endpoint — access is gated by the client's access key and permission settings.
+
+---
 
 ## Source
 

--- a/docs/server/docker.md
+++ b/docs/server/docker.md
@@ -1,6 +1,11 @@
 # Docker Deployment
 
-Run `hivemind-core` in Docker for easy deployment and isolation.
+**`hivemind-core` runs in Docker for easy deployment and isolation.**
+
+!!! abstract "In a nutshell"
+    - There is no published all-in-one image; containers are built locally from the `hivemind-skills-server-docker` compose stack or based on the `smartgic/*` images.
+    - `hivemind-core` reads no environment variables — all configuration is the `server.json` file mounted into the non-root `hivemind` user's config directory.
+    - The stack uses `network_mode: host`; SQLite is the default database, with Redis for multi-instance deployments.
 
 There is no published "all-in-one" hivemind-core image on the JarbasHiveMind
 namespace. Containers are either:
@@ -17,10 +22,12 @@ namespace. Containers are either:
 The examples below follow the `hivemind-skills-server-docker` stack, which builds
 its hivemind image locally.
 
+---
+
 ## How config works in the container
 
 `hivemind-core` reads **no environment variables**. All configuration is the
-`server.json` file described in [OVOS Skills Hub](ovos-hub.md#configuration). In a
+`server.json` file described in [OVOS Skills Server](ovos-hub.md#configuration). In a
 container you supply it by mounting a host folder onto the config directory of the
 non-root `hivemind` user:
 
@@ -33,6 +40,8 @@ non-root `hivemind` user:
 The client database, certificates, etc. live under
 `/home/hivemind/.local/share/hivemind` — not `/root/...`, because the image runs as
 the unprivileged `hivemind` user.
+
+---
 
 ## Basic deployment
 
@@ -84,6 +93,8 @@ docker compose logs -f hivemind_core
 > The stack uses `network_mode: host`, so the WebSocket (5678) and HTTP (5679)
 > listeners are reachable directly on the host; published `ports:` are cosmetic
 > under host networking.
+
+---
 
 ## Redis backend
 
@@ -138,21 +149,27 @@ services:
 The default backend is SQLite (stdlib, transactional); switch to Redis only if you
 need it for a multi-instance / shared-store deployment.
 
+---
+
 ## Persona service
 
-The same stack can run a [persona hub](persona-hub.md) container (`hivemind_persona`,
+The same stack can run a [persona server](persona-hub.md) container (`hivemind_persona`,
 built from `Dockerfile.persona`, which is `FROM smartgic/hivemind-base`) that exposes
 HiveMind to OpenAI/Ollama-compatible apps. Its `VOICE_SAT_*` env vars are *client
 credentials* it uses to connect back to `hivemind_core`; they must first be provisioned
 with `hivemind-core add-client`.
 
+---
+
 ## With SSL via reverse proxy
 
-For production you can terminate TLS at a reverse proxy (nginx, Caddy) in front of the
-hub, or enable TLS natively per network protocol in `server.json`
+For production you can terminate TLS at a reverse proxy (nginx, Caddy) in front of
+`hivemind-core`, or enable TLS natively per network protocol in `server.json`
 (`network_protocol.<plugin>.ssl = true`, plus `cert_dir`/`cert_name`).
 
 When proxying, don't also expose 5678/5679 directly to the internet.
+
+---
 
 ## Management commands
 
@@ -176,9 +193,11 @@ docker compose exec hivemind_core hivemind-core allow-msg "speak" 2
 docker compose exec hivemind_core hivemind-core blacklist-skill "skill-homeassistant.openvoiceos" 2
 ```
 
+---
+
 ## Troubleshooting
 
-**Satellite cannot reach the hub**: with `network_mode: host`, check the host's port
+**Satellite cannot reach `hivemind-core`**: with `network_mode: host`, check the host's port
 5678 (and 5679) is reachable from the satellite network and not firewalled.
 
 **Cannot connect to Redis**: verify Redis is running
@@ -188,6 +207,8 @@ docker compose exec hivemind_core hivemind-core blacklist-skill "skill-homeassis
 **Config changes ignored**: confirm your `server.json` is on the host folder mounted at
 `/home/hivemind/.config/hivemind-core`, and restart the container — the persona file
 and most config are read at startup only.
+
+---
 
 ## Source
 

--- a/docs/server/docker.md
+++ b/docs/server/docker.md
@@ -27,7 +27,7 @@ its hivemind image locally.
 ## How config works in the container
 
 `hivemind-core` reads **no environment variables**. All configuration is the
-`server.json` file described in [OVOS Skills Server](ovos-hub.md#configuration). In a
+`server.json` file described in [OVOS Skills Server](ovos-server.md#configuration). In a
 container you supply it by mounting a host folder onto the config directory of the
 non-root `hivemind` user:
 
@@ -153,7 +153,7 @@ need it for a multi-instance / shared-store deployment.
 
 ## Persona service
 
-The same stack can run a [persona server](persona-hub.md) container (`hivemind_persona`,
+The same stack can run a [persona server](persona-server.md) container (`hivemind_persona`,
 built from `Dockerfile.persona`, which is `FROM smartgic/hivemind-base`) that exposes
 HiveMind to OpenAI/Ollama-compatible apps. Its `VOICE_SAT_*` env vars are *client
 credentials* it uses to connect back to `hivemind_core`; they must first be provisioned

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -1,34 +1,38 @@
-# Hub & Server
+# hivemind-core Server
 
-The **hub** is the central brain of a HiveMind. It accepts connections from
+**`hivemind-core`** is the central brain of a HiveMind. It accepts connections from
 satellites, decides what AI backend answers them, and enforces who is allowed to do
-what. This section is for whoever **runs** the hub.
+what. This section is for whoever **runs** the server.
 
-!!! tip "Which hub do I want?"
-    The hub's "personality" is set by one choice: **which agent plugin answers
+!!! tip "Which server do I want?"
+    A server's "personality" is set by one choice: **which agent plugin answers
     requests**. Pick by what you want the assistant to *be*:
 
-    - **A full voice assistant with skills** → [OVOS Skills Hub](ovos-hub.md)
-    - **A chatbot / LLM** (no skills needed) → [Persona Hub](persona-hub.md)
-    - **An external AI agent** (A2A protocol) → [A2A Hub](a2a-hub.md)
+    - **A full voice assistant with skills** → [OVOS Skills Server](ovos-hub.md)
+    - **A chatbot / LLM** (no skills needed) → [Persona Server](persona-hub.md)
+    - **An external AI agent** (A2A protocol) → [A2A Server](a2a-hub.md)
 
     Not sure, or want the easy path? The [Admin Panel](admin-panel.md) is a web UI that
-    launches a hub **and** lets you administer it from the browser — one command.
+    launches a `hivemind-core` instance **and** lets you administer it from the browser — one command.
+
+---
 
 ## What's in this section
 
 | Page | What it covers |
 |---|---|
-| [Admin Panel](admin-panel.md) | A web UI that launches a hub and administers it — the easiest way to run one. |
-| [OVOS Skills Hub](ovos-hub.md) | The default hub: serves OpenVoiceOS skills, STT, and TTS. |
-| [Persona Hub (LLM)](persona-hub.md) | Serve an LLM/chatbot persona — no `ovos-core` required. |
-| [A2A Hub (Agents)](a2a-hub.md) | Bridge to any agent speaking Google's Agent-to-Agent protocol. |
+| [Admin Panel](admin-panel.md) | A web UI that launches a `hivemind-core` instance and administers it — the easiest way to run one. |
+| [OVOS Skills Server](ovos-hub.md) | The default setup: serves OpenVoiceOS skills, STT, and TTS. |
+| [Persona Server (LLM)](persona-hub.md) | Serve an LLM/chatbot persona — no `ovos-core` required. |
+| [A2A Server (Agents)](a2a-hub.md) | Bridge to any agent speaking Google's Agent-to-Agent protocol. |
 | [Transports](transports.md) | How bytes travel: WebSocket (default), HTTP, MQTT, Usenet. |
 | [Audio Binary Protocol](audio-binary-protocol.md) | How raw audio (wake word, STT, TTS streams) travels to/from thin satellites. |
-| [Docker Deployment](docker.md) | Run the hub and the OVOS stack in containers. |
+| [Docker Deployment](docker.md) | Run `hivemind-core` and the OVOS stack in containers. |
 | [Operations](operations.md) | Day-2 concerns: TLS, reconnection, monitoring, connection errors. |
 
-## How a request flows through the hub
+---
+
+## How a request flows through hivemind-core
 
 ```
 satellite ──▶ transport plugin ──▶ permission check ──▶ agent plugin ──▶ AI backend
@@ -41,4 +45,4 @@ three is swappable — see [Plugin Architecture](../concepts/plugins.md).
 
 ---
 
-**Next:** [OVOS Skills Hub](ovos-hub.md) · or [Quick Start](../quickstart.md) to stand one up now.
+**Next:** [OVOS Skills Server](ovos-hub.md) · or [Quick Start](../quickstart.md) to stand one up now.

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -8,9 +8,9 @@ what. This section is for whoever **runs** the server.
     A server's "personality" is set by one choice: **which agent plugin answers
     requests**. Pick by what you want the assistant to *be*:
 
-    - **A full voice assistant with skills** → [OVOS Skills Server](ovos-hub.md)
-    - **A chatbot / LLM** (no skills needed) → [Persona Server](persona-hub.md)
-    - **An external AI agent** (A2A protocol) → [A2A Server](a2a-hub.md)
+    - **A full voice assistant with skills** → [OVOS Skills Server](ovos-server.md)
+    - **A chatbot / LLM** (no skills needed) → [Persona Server](persona-server.md)
+    - **An external AI agent** (A2A protocol) → [A2A Server](a2a-server.md)
 
     Not sure, or want the easy path? The [Admin Panel](admin-panel.md) is a web UI that
     launches a `hivemind-core` instance **and** lets you administer it from the browser — one command.
@@ -22,9 +22,9 @@ what. This section is for whoever **runs** the server.
 | Page | What it covers |
 |---|---|
 | [Admin Panel](admin-panel.md) | A web UI that launches a `hivemind-core` instance and administers it — the easiest way to run one. |
-| [OVOS Skills Server](ovos-hub.md) | The default setup: serves OpenVoiceOS skills, STT, and TTS. |
-| [Persona Server (LLM)](persona-hub.md) | Serve an LLM/chatbot persona — no `ovos-core` required. |
-| [A2A Server (Agents)](a2a-hub.md) | Bridge to any agent speaking Google's Agent-to-Agent protocol. |
+| [OVOS Skills Server](ovos-server.md) | The default setup: serves OpenVoiceOS skills, STT, and TTS. |
+| [Persona Server (LLM)](persona-server.md) | Serve an LLM/chatbot persona — no `ovos-core` required. |
+| [A2A Server (Agents)](a2a-server.md) | Bridge to any agent speaking Google's Agent-to-Agent protocol. |
 | [Transports](transports.md) | How bytes travel: WebSocket (default), HTTP, MQTT, Usenet. |
 | [Audio Binary Protocol](audio-binary-protocol.md) | How raw audio (wake word, STT, TTS streams) travels to/from thin satellites. |
 | [Docker Deployment](docker.md) | Run `hivemind-core` and the OVOS stack in containers. |
@@ -45,4 +45,4 @@ three is swappable — see [Plugin Architecture](../concepts/plugins.md).
 
 ---
 
-**Next:** [OVOS Skills Server](ovos-hub.md) · or [Quick Start](../quickstart.md) to stand one up now.
+**Next:** [OVOS Skills Server](ovos-server.md) · or [Quick Start](../quickstart.md) to stand one up now.

--- a/docs/server/operations.md
+++ b/docs/server/operations.md
@@ -61,7 +61,7 @@ The Docker deployment guide covers a concrete proxy setup; see
 ## systemd
 
 Run `hivemind-core` as a managed service. Reuse the unit from the
-[OVOS Skills Server](ovos-hub.md#systemd-service) guide:
+[OVOS Skills Server](ovos-server.md#systemd-service) guide:
 
 ```ini
 # /etc/systemd/system/hivemind-core.service
@@ -89,7 +89,7 @@ sudo systemctl start hivemind-core
 
 The `After=`/`Requires=ovos-messagebus.service` lines matter for an **OVOS skills server**:
 its agent protocol talks to `ovos-messagebus`, which must be up first. An
-[A2A server](a2a-hub.md) or [persona server](persona-hub.md) does not require `ovos-messagebus`
+[A2A server](a2a-server.md) or [persona server](persona-server.md) does not require `ovos-messagebus`
 — drop those two lines if you are not running OVOS.
 
 ---

--- a/docs/server/operations.md
+++ b/docs/server/operations.md
@@ -1,9 +1,16 @@
 # Operations
 
-Running `hivemind-core` in production. This page consolidates TLS, reverse-proxy,
+**This page covers running `hivemind-core` in production** — TLS, reverse-proxy,
 service-management, observability, and scaling concerns for an operator. Everything here
-is driven by `~/.config/hivemind-core/server.json` and standard system tooling —
+is driven by `~/.config/hivemind-core/server.json` and standard system tooling;
 `hivemind-core listen` takes no command-line flags.
+
+!!! abstract "In a nutshell"
+    - TLS is configured per network protocol in `server.json`, or terminated at a reverse proxy in front of `hivemind-core`.
+    - `hivemind-core` emits `hive.client.connect` / `disconnect` / `connection.error` events on the OVOS messagebus, and logs rejected connections at `ERROR`.
+    - SQLite and JSON backends are single-node; Redis is the shared backend for running multiple `hivemind-core` instances against one store.
+
+---
 
 ## TLS
 
@@ -33,13 +40,15 @@ certificate is sufficient; satellites must then be told to accept it by passing
 `--selfsigned` on their connect commands (`hivemind-voice-sat`, `hivemind-voice-relay`,
 HiveMind-cli, …). For anything exposed beyond the LAN, serve a CA-issued certificate so
 satellites validate it normally — or terminate TLS at a reverse proxy (below) and leave
-the hub itself plaintext on the loopback interface. See
+`hivemind-core` itself plaintext on the loopback interface. See
 [Security](../concepts/security.md) for the certificate guidance.
+
+---
 
 ## Reverse proxy
 
 For production it is common to terminate TLS at nginx or Caddy in front of the WebSocket
-hub rather than configuring `ssl` on the hub itself. The proxy holds the real (CA-issued)
+listener rather than configuring `ssl` on `hivemind-core` itself. The proxy holds the real (CA-issued)
 certificate on `443` and forwards to `hivemind-core` on `127.0.0.1:5678`, upgrading the
 WebSocket connection. When you do this, do **not** also expose `5678`/`5679` directly to
 the internet — only the proxy should be reachable.
@@ -47,10 +56,12 @@ the internet — only the proxy should be reachable.
 The Docker deployment guide covers a concrete proxy setup; see
 [Docker Deployment](docker.md#with-ssl-via-reverse-proxy).
 
+---
+
 ## systemd
 
-Run the hub as a managed service. Reuse the unit from the
-[OVOS Skills Hub](ovos-hub.md#systemd-service) guide:
+Run `hivemind-core` as a managed service. Reuse the unit from the
+[OVOS Skills Server](ovos-hub.md#systemd-service) guide:
 
 ```ini
 # /etc/systemd/system/hivemind-core.service
@@ -76,15 +87,17 @@ sudo systemctl enable hivemind-core
 sudo systemctl start hivemind-core
 ```
 
-The `After=`/`Requires=ovos-messagebus.service` lines matter for an **OVOS skills hub**:
+The `After=`/`Requires=ovos-messagebus.service` lines matter for an **OVOS skills server**:
 its agent protocol talks to `ovos-messagebus`, which must be up first. An
-[A2A hub](a2a-hub.md) or [persona hub](persona-hub.md) does not require `ovos-messagebus`
+[A2A server](a2a-hub.md) or [persona server](persona-hub.md) does not require `ovos-messagebus`
 — drop those two lines if you are not running OVOS.
+
+---
 
 ## Connection errors and observability
 
-Hub-side connection failures mostly surface to the client as a silent socket disconnect —
-the satellite simply fails to complete the handshake. Server-side, however, the hub emits
+Server-side connection failures mostly surface to the client as a silent socket disconnect —
+the satellite simply fails to complete the handshake. Server-side, however, `hivemind-core` emits
 internal-bus events on the OVOS messagebus that its agent protocol is wired to (in OVOS
 mode this is `ovos-messagebus`). Rejected connections raise an error event:
 
@@ -107,7 +120,7 @@ distinct `error` payload values, so you can tell them apart:
 An operator can observe invalid-key and bad-protocol-version attempts in two ways:
 
 1. **Watch the messagebus.** Listen for `hive.client.connection.error` on the OVOS
-   messagebus the hub publishes to (for an OVOS hub, the `ovos-messagebus` the agent
+   messagebus `hivemind-core` publishes to (for an OVOS skills server, the `ovos-messagebus` the agent
    protocol connects to) and inspect the `error`/`peer` fields. This is the structured,
    real-time signal — wire it into your monitoring to alert on repeated rejected
    connections from a single peer (a sign of a misconfigured satellite or a brute-force
@@ -120,17 +133,19 @@ An operator can observe invalid-key and bad-protocol-version attempts in two way
 Normal `hive.client.connect` / `hive.client.disconnect` events on the same bus give you a
 running picture of which satellites are attached.
 
+---
+
 ## Scaling and multi-instance
 
-A single hub keeps client and permission state in its [database
+A single `hivemind-core` instance keeps client and permission state in its [database
 backend](../concepts/databases.md). The backend choice determines whether you can run
-more than one hub instance against the same state:
+more than one instance against the same state:
 
 - **SQLite** (default) and **JSON** are single-node — the database is a local file; only
   one `hivemind-core` process should own it.
 - **Redis** ([`hivemind-redis-database`](../concepts/databases.md)) is the shared backend.
   Point multiple `hivemind-core` instances at the same Redis and they share client
-  records and permissions, so you can run several hubs (behind a load balancer, or for
+  records and permissions, so you can run several instances (behind a load balancer, or for
   redundancy) without each maintaining its own client list. Add a client once and every
   instance sees it.
 
@@ -138,6 +153,8 @@ Select the backend in `server.json` under the `database` block; the same configu
 read by `listen` and by every client-management command, so they all operate on the same
 store. See [Database Backends](../concepts/databases.md) for the full configuration and
 the `migrate-db` workflow.
+
+---
 
 ## Health checking
 
@@ -153,17 +170,21 @@ practical rather than built-in:
   `Restart=on-failure` policy cover process-level health; pair that with the socket probe
   above for the network path.
 - **Presence announce/scan.** If [HiveMind-presence](../concepts/discovery.md) is running
-  alongside the hub, a `hivemind-presence scan` should find the hub's announcement on the
+  alongside `hivemind-core`, a `hivemind-presence scan` should find its announcement on the
   local network — a coarse confirmation that the node is reachable and advertising. Note
   presence is an optional, separate process from `hivemind-core listen`, so its absence
-  does not by itself mean the hub is down.
+  does not by itself mean `hivemind-core` is down.
+
+---
 
 ## Next
 
-- [Docker Deployment](docker.md) — containerized hub, Redis, and the reverse-proxy setup.
+- [Docker Deployment](docker.md) — containerized `hivemind-core`, Redis, and the reverse-proxy setup.
 - [Database Backends](../concepts/databases.md) — single-node vs shared (Redis) state.
 - [Security](../concepts/security.md) — certificates, keys, and permissions.
 - [Discovery](../concepts/discovery.md) — presence announce/scan for health and reach.
+
+---
 
 ## Source
 

--- a/docs/server/ovos-hub.md
+++ b/docs/server/ovos-hub.md
@@ -1,6 +1,13 @@
-# OVOS Skills Hub
+# OVOS Skills Server
 
-The canonical `hivemind-core` hub, backed by an OpenVoiceOS instance. Satellites connect to it and route utterances to OVOS skills.
+**The OVOS Skills Server is the canonical `hivemind-core` setup**, backed by an OpenVoiceOS instance. Satellites connect to it and route utterances to OVOS skills, STT, and TTS.
+
+!!! abstract "In a nutshell"
+    - A `hivemind-core` server whose agent protocol talks to a local `ovos-core` / `ovos-messagebus` on `127.0.0.1:8181`.
+    - All settings live in `~/.config/hivemind-core/server.json`; `hivemind-core listen` takes no flags.
+    - Manage satellites with the `hivemind-core` client CLI (node IDs are positional).
+
+---
 
 ## Prerequisites
 
@@ -12,11 +19,15 @@ pip install ovos-core ovos-messagebus
 
 See the [OVOS documentation](https://openvoiceos.github.io/community-docs) for a complete OVOS setup guide.
 
+---
+
 ## Install
 
 ```bash
 pip install hivemind-core
 ```
+
+---
 
 ## Configuration
 
@@ -96,6 +107,8 @@ TLS is enabled per network protocol by setting `ssl` to `true` and pointing `cer
     pluggable — MQTT and an experimental Usenet transport also exist. See
     [Transports](transports.md) for the full status table.
 
+---
+
 ## Starting the server
 
 ```bash
@@ -103,6 +116,8 @@ hivemind-core listen
 ```
 
 All behaviour comes from `server.json`; there are no flags to pass here.
+
+---
 
 ## Managing clients
 
@@ -124,6 +139,8 @@ hivemind-core rename-client --name "new-name" 2
 
 See [CLI Reference](../reference/cli.md) for all commands and [Security](../concepts/security.md#permissions) for permission management.
 
+---
+
 ## Adding server-side audio processing
 
 To support mic-satellite and voice-relay, install the audio binary protocol plugin:
@@ -133,6 +150,8 @@ pip install hivemind-audio-binary-protocol
 ```
 
 Then configure `server.json` to enable it. See [Audio Binary Protocol](audio-binary-protocol.md).
+
+---
 
 ## Systemd service
 
@@ -162,15 +181,17 @@ sudo systemctl enable hivemind-core
 sudo systemctl start hivemind-core
 ```
 
-## Other hub flavors
+---
+
+## Other agent flavors
 
 Beyond the OVOS, [persona](persona-hub.md), and [A2A](a2a-hub.md) agent plugins, two
 more agent-plugin flavors exist for advanced or experimental setups. Both are
 **alpha / unpublished — install from the repo and read its README**.
 
-??? note "Advanced: other hub flavors"
+??? note "Advanced: other agent flavors"
     **localhive** ([`hivemind-localhive-agent-plugin`](https://github.com/JarbasHiveMind/hivemind-localhive-agent-plugin))
-    — an "isolated-skills hub". It runs OVOS skills *in-process* (no separate
+    — an "isolated-skills" agent. It runs OVOS skills *in-process* (no separate
     `ovos-core` / `ovos-messagebus`), but each skill only ever sees its own messages.
     Here `skill_id` is purely a routing label, not a credential — one skill cannot
     eavesdrop on another's traffic. Useful when you want OVOS skills without a full
@@ -180,7 +201,9 @@ more agent-plugin flavors exist for advanced or experimental setups. Both are
     — a per-access-key agent *multiplexer*. Every access key gets its own isolated
     agent instance (by default a bundled MiniCroft brain), and each key's
     `{module, config}` is stored in that client's DB metadata. This is the
-    multi-tenant story: one hub, many independent assistants, one per satellite key.
+    multi-tenant story: one server, many independent assistants, one per satellite key.
+
+---
 
 ## Source
 

--- a/docs/server/ovos-server.md
+++ b/docs/server/ovos-server.md
@@ -185,7 +185,7 @@ sudo systemctl start hivemind-core
 
 ## Other agent flavors
 
-Beyond the OVOS, [persona](persona-hub.md), and [A2A](a2a-hub.md) agent plugins, two
+Beyond the OVOS, [persona](persona-server.md), and [A2A](a2a-server.md) agent plugins, two
 more agent-plugin flavors exist for advanced or experimental setups. Both are
 **alpha / unpublished — install from the repo and read its README**.
 

--- a/docs/server/persona-hub.md
+++ b/docs/server/persona-hub.md
@@ -1,14 +1,21 @@
-# Persona Hub
+# Persona Server
 
-A "persona hub" is a regular `hivemind-core` server whose **agent protocol** is the
-[ovos-persona](https://github.com/OpenVoiceOS/ovos-persona) plugin. Instead of routing
-utterances into a full OVOS skills stack, the hub answers natural-language queries
+**A persona server is a regular `hivemind-core` server whose agent protocol is the
+[ovos-persona](https://github.com/OpenVoiceOS/ovos-persona) plugin.** Instead of routing
+utterances into a full OVOS skills stack, it answers natural-language queries
 directly from an LLM / chatbot / solver-chain persona — no `ovos-core` required.
 
+!!! abstract "In a nutshell"
+    - Swaps the `agent_protocol` for `hivemind-persona-agent-plugin`, so `hivemind-core` answers queries from an LLM / solver chain.
+    - The persona is a JSON document listing solver plugins (e.g. `ovos-solver-openai-plugin`) and their config.
+    - Text-based satellites and bridges work against it; audio-binary-protocol satellites do not.
+
 Satellites built for `hivemind-core` (text-based ones like HiveMind-cli, voice-sat, or
-bridges) work against a persona hub. Satellites that depend on the audio binary
-protocol (`hivemind-audio-binary-protocol`) do **not** apply here — a persona hub
+bridges) work against a persona server. Satellites that depend on the audio binary
+protocol (`hivemind-audio-binary-protocol`) do **not** apply here — a persona server
 exposes a text/query agent, not server-side audio processing.
+
+---
 
 ## Install
 
@@ -24,6 +31,8 @@ pip install ovos-openai-plugin
 ```
 
 This provides the `ovos-solver-openai-plugin` solver.
+
+---
 
 ## Configure the persona
 
@@ -50,6 +59,8 @@ Save it somewhere (for example `~/.config/ovos_persona/persona.json`):
 The OpenAI solver keys are `api_url`, `key`, `model`, and `system_prompt` — there is no
 `persona` key inside the solver block; the persona is the surrounding document.
 
+---
+
 ## Configure hivemind-core
 
 Point the `agent_protocol` block in `~/.config/hivemind-core/server.json` at the
@@ -70,14 +81,18 @@ persona plugin, and give it the persona to run:
 persona config dict. The file is read once at startup; restart `hivemind-core` to pick
 up edits.
 
+---
+
 ## Start the server
 
 ```bash
 hivemind-core listen
 ```
 
-Satellites connecting to this hub now receive answers streamed from the persona,
+Satellites connecting to this server now receive answers streamed from the persona,
 sentence by sentence.
+
+---
 
 ## Managing clients
 
@@ -95,7 +110,9 @@ hivemind-core list-clients
 hivemind-core delete-client 2
 ```
 
-See [OVOS Skills Hub](ovos-hub.md#managing-clients) for the full client workflow.
+See [OVOS Skills Server](ovos-hub.md#managing-clients) for the full client workflow.
+
+---
 
 ## Solver plugins
 
@@ -105,6 +122,8 @@ Any `ovos-solver-*` plugin can back the persona. Common ones:
   vLLM, …), installed via `pip install ovos-openai-plugin`.
 - `ovos-solver-failure-plugin` — always returns a fallback response (useful for
   testing).
+
+---
 
 ## Example personas
 
@@ -145,6 +164,8 @@ Any `ovos-solver-*` plugin can back the persona. Common ones:
   ]
 }
 ```
+
+---
 
 ## Source
 

--- a/docs/server/persona-server.md
+++ b/docs/server/persona-server.md
@@ -110,7 +110,7 @@ hivemind-core list-clients
 hivemind-core delete-client 2
 ```
 
-See [OVOS Skills Server](ovos-hub.md#managing-clients) for the full client workflow.
+See [OVOS Skills Server](ovos-server.md#managing-clients) for the full client workflow.
 
 ---
 

--- a/docs/server/transports.md
+++ b/docs/server/transports.md
@@ -1,15 +1,22 @@
 # Transports
 
-A **transport** is *how* bytes travel between a satellite and the hub. WebSocket is the
+**A transport is how bytes travel between a satellite and `hivemind-core`.** WebSocket is the
 default; the others suit special cases. The important part: the
 [encryption](../concepts/security.md) and the message format are **identical across all
-of them** — only the carrier changes. A satellite and a hub agree on a transport, but
+of them** — only the carrier changes. A satellite and `hivemind-core` agree on a transport, but
 what they send over it is the same encrypted HiveMind protocol either way.
+
+!!! abstract "In a nutshell"
+    - Transports register under the `hivemind.network.protocol` plugin entry-point group; the carrier is swappable without touching encryption or the message format.
+    - WebSocket (port `5678`) is the reference and default; HTTP is request/response.
+    - MQTT is broker-mediated (alpha) and Usenet is store-and-forward (experimental, git-only) — in both the carrier only ever sees ciphertext.
 
 !!! tip "You rarely need to change this"
     If you don't know which transport you want, you want WebSocket — it's the
     reference implementation and the default in every example. The rest of this page is
     for people with a specific need (broker-mediated IoT, censorship-resistant relay).
+
+---
 
 ## Status at a glance
 
@@ -29,12 +36,16 @@ read the **PyPI status** column before you build on one:
     `pip install hivemind-usenet` works — it is not on PyPI, and it depends on
     git-only carrier libraries. Treat both as for-the-curious until they ship to PyPI.
 
+---
+
 ## WebSocket (default)
 
 The reference transport. A persistent, bidirectional socket on port `5678`. TLS is
 enabled per protocol in `server.json` by setting `ssl: true` and pointing
 `cert_dir` / `cert_name` at the certificate to serve (see
 [Operations → TLS](operations.md#tls)). This is what every quickstart and example uses.
+
+---
 
 ## HTTP
 
@@ -47,6 +58,8 @@ back in the response.
     default `server.json` ships it on `5679` as a deliberate override. If you enable
     the HTTP plugin and forget to set `port`, it will collide with the WebSocket
     listener. Always give the HTTP block its own port.
+
+---
 
 ## MQTT (alpha)
 
@@ -69,6 +82,8 @@ back in the response.
 
     This is **alpha** — pin and test before relying on it.
 
+---
+
 ## Usenet (experimental)
 
 ??? note "Advanced: censorship-resistant store-and-forward"
@@ -79,19 +94,25 @@ back in the response.
     carrier libraries. Do not write deployment docs that assume
     `pip install hivemind-usenet` works.
 
+---
+
 ## Not a transport: the audio binary protocol
 
 The [Audio Binary Protocol](audio-binary-protocol.md) is a *different* kind of plugin.
 It is **not** a network transport — it's a binary **payload handler** (entry-point group
 `hivemind.binary.protocol`) that runs *on top of* whichever transport you chose, so the
-hub can receive raw audio, run wake-word/STT/TTS, and stream audio back. You can mix it
+server can receive raw audio, run wake-word/STT/TTS, and stream audio back. You can mix it
 with any transport above. See [Audio Binary Protocol](audio-binary-protocol.md).
+
+---
 
 ## How this all plugs together
 
 Every transport is a [plugin](../concepts/plugins.md) discovered by entry point, which
 is why swapping the carrier doesn't touch the encryption or the message format. See
-[Plugin Architecture](../concepts/plugins.md) for how the hub resolves and loads them.
+[Plugin Architecture](../concepts/plugins.md) for how `hivemind-core` resolves and loads them.
+
+---
 
 ## Source
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: HiveMind Documentation
 site_url: https://jarbashivemind.github.io/HiveMind-community-docs/
 site_description: >-
   The official manual for HiveMind — the open-source protocol that connects
-  lightweight satellite devices to a central voice/AI hub over an encrypted mesh.
+  lightweight satellite devices to a central hivemind-core server over an encrypted mesh.
 repo_url: https://github.com/JarbasHiveMind
 repo_name: JarbasHiveMind
 
@@ -22,15 +22,15 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: amber
-      accent: deep orange
+      primary: light blue
+      accent: blue
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: amber
-      accent: deep orange
+      primary: light blue
+      accent: blue
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
@@ -86,7 +86,7 @@ nav:
   - FAQ: faq.md
   - Core Concepts:
     - concepts/index.md
-    - Mesh & Hub Topology: concepts/mesh.md
+    - Mesh Topology: concepts/mesh.md
     - Protocol & Message Types: concepts/protocol.md
     - Security & Permissions: concepts/security.md
     - Database Backends: concepts/databases.md
@@ -102,12 +102,12 @@ nav:
     - WebSpeech Browser: satellites/webspeech.md
     - Microcontrollers (ESP32): satellites/microcontrollers.md
 
-  - Hub & Server:
+  - Self-Hosting:
     - server/index.md
     - Admin Panel: server/admin-panel.md
-    - OVOS Skills Hub: server/ovos-hub.md
-    - Persona Hub (LLM): server/persona-hub.md
-    - A2A Hub (Agents): server/a2a-hub.md
+    - OVOS Skills Server: server/ovos-hub.md
+    - Persona Server (LLM): server/persona-hub.md
+    - A2A Server (Agents): server/a2a-hub.md
     - Transports: server/transports.md
     - Audio Binary Protocol: server/audio-binary-protocol.md
     - Docker Deployment: server/docker.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,9 +105,9 @@ nav:
   - Self-Hosting:
     - server/index.md
     - Admin Panel: server/admin-panel.md
-    - OVOS Skills Server: server/ovos-hub.md
-    - Persona Server (LLM): server/persona-hub.md
-    - A2A Server (Agents): server/a2a-hub.md
+    - OVOS Skills Server: server/ovos-server.md
+    - Persona Server (LLM): server/persona-server.md
+    - A2A Server (Agents): server/a2a-server.md
     - Transports: server/transports.md
     - Audio Binary Protocol: server/audio-binary-protocol.md
     - Docker Deployment: server/docker.md


### PR DESCRIPTION
Corrects the browser/JS crypto docs to the shipped v3 reality and brings the whole manual in line with the OVOS Technical Manual conventions.

## Crypto correction
Browser and JavaScript clients ([HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)) negotiate the default `Noise_XXpsk2_25519_ChaChaPoly_SHA256` suite and derive `PSK = argon2id(password, SHA-256(node_id))` in-browser via `@noble`, giving full cipher parity with hivemind-core — no server-side configuration. A provisioned `psk` is optional; PBKDF2 is an explicit fallback; only a minimal bundle without `@noble` degrades to the AES-GCM/PBKDF2 subset. (`concepts/security.md`, `satellites/webspeech.md`, `developers/protocol-spec.md`.)

## Manual-style pass (all pages)
- Bold-lead intro + an `!!! abstract "In a nutshell"` summary on every substantive page; `---` rules between top-level sections; timeless, standalone, present-tense prose with all meta-commentary removed.

## Terminology
- The central server is named explicitly **hivemind-core** everywhere (prose, nutshells, tables, diagrams, nav); the agent-backend pages are titled **OVOS Skills / Persona / A2A Server**. No "hub"/"fleet".

## Theme
- Material palette switched from amber/orange to **light blue** in both light and dark schemes.

`mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)