### PR TITLE
docs: narrative voice pass — noob-friendly + developer-deep, with restored nested-hives page and flow diagrams

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,87 +1,84 @@
 # What is HiveMind?
 
-**HiveMind is an open-source protocol and platform** that connects lightweight **satellite** devices to a central AI server — **hivemind-core** — over the network, including hardware that cannot run a full AI system on its own.
+Voice assistants like Alexa or Google Home are two things wearing one shell: the
+*ears and mouth* (a microphone and a speaker) and the *brain* (the part that
+understands you and answers). In those products the brain lives in someone else's
+data center, and every word you say takes a trip to the cloud.
+
+HiveMind pulls those two apart. You run the brain once, on a computer in your own
+home, and the ears and mouth become small, cheap, interchangeable devices —
+**satellites** — that connect to it over your network. The brain is
+**hivemind-core**. Everything else plugs into it.
 
 !!! abstract "In a nutshell"
-    - Satellites delegate reasoning, skills, and audio processing to hivemind-core, which serves many of them with independent sessions and permissions.
-    - Configure hivemind-core with an OVOS skills backend for home automation and skills, or a persona backend to just chat with an LLM.
-    - Satellites range from text-only CLI clients to full local voice stacks; hivemind-core instances can chain into a mesh.
-    - HiveMind is a gateway around OVOS, not a replacement for it, and runs entirely on your own hardware.
+    - Satellites handle *hearing and speaking*; hivemind-core handles *understanding and answering* — and serves many satellites at once, each with its own identity and permissions.
+    - Give hivemind-core an OVOS skills back end for a full voice assistant, or a persona back end to just chat with an LLM.
+    - Satellites range from a one-line CLI to a full offline voice stack — the thinner the device, the more hivemind-core does for it.
+    - It's a private gateway around your own assistant, running entirely on hardware you own.
 
-## The core idea
+## Why split them apart?
 
-HiveMind separates AI workload from edge devices. Satellites (microphones, voice devices, browsers, chat clients) delegate processing to hivemind-core, which handles reasoning, skills, and audio processing. hivemind-core can serve many satellites simultaneously with independent sessions and permissions for each.
+Because the brain is expensive and the ears are cheap.
 
-New here? The [Glossary](reference/glossary.md) defines every term on this page.
+Speech recognition, intent parsing, and an LLM need real memory and CPU. A doorway
+sensor, a desk button, or a ten-dollar board has none of that — but it has a
+microphone, and that's all a satellite needs. Run the brain *once*, on a machine
+that can handle it, and every underpowered gadget in the house can offer the full
+assistant just by forwarding audio to hivemind-core and playing back the reply.
+
+Three things fall out of that split, for free:
+
+- **Privacy.** The brain is in your closet, not a cloud. Your voice never leaves the
+  building unless *you* send it somewhere.
+- **Reach.** Anything that can open a network connection can be a satellite — a
+  browser tab, a microcontroller, a phone, a Raspberry Pi, a chat room.
+- **Resilience.** No internet? No problem. Satellites talk to hivemind-core over the
+  local network, so the assistant keeps working in a blackout or a cabin off the grid.
 
 ```
 [Mic Satellite]  ──┐
-[Voice Relay]    ───┤──→ [hivemind-core] ──→ skills / LLM / intents
-[Voice Satellite]──┤         │
-[CLI Client]     ───┘        └──→ responses back to each satellite
+[Voice Relay]    ──┤──→  hivemind-core  ──→  skills · LLM · intents
+[Browser Tab]    ──┤        (the brain)
+[CLI Client]     ──┘        └──→  the reply goes back to whichever satellite asked
 ```
 
----
+## What's the brain, exactly?
 
-## Backend types
+hivemind-core is the meeting point — it authenticates satellites, routes messages,
+and enforces permissions. It is *not* the intelligence itself. You choose that and
+plug it in:
 
-Pick the **[OVOS](reference/glossary.md#ovos-voice-vocabulary) skills backend** if you want skills/home-automation; pick the **[Persona](reference/glossary.md#ovos-voice-vocabulary) backend** if you just want to chat with an LLM and want the simplest setup (no OVOS required).
-
-| Backend | Package | Agent backend |
+| Back end | You get | Good for |
 |---|---|---|
-| OVOS skills server | `hivemind-core` | OpenVoiceOS (full skill ecosystem) |
-| Audio server | `hivemind-core` + `hivemind-audio-binary-protocol` | OVOS + server-side [STT](reference/glossary.md#ovos-voice-vocabulary)/[TTS](reference/glossary.md#ovos-voice-vocabulary)/wakeword |
-| Persona server | `hivemind-core` + `hivemind-persona-agent-plugin` | LLMs and chatbots via `ovos-persona` |
+| **OVOS skills server** | a full private voice assistant — weather, timers, music, home control, hundreds of skills | replacing a smart speaker |
+| **Persona (LLM)** | an LLM with a personality, no skills, simplest setup | open-ended conversation |
+| **Your own** | anything, via the agent-protocol plugins | custom back ends |
 
----
+Swap the back end and the satellites never notice — they only ever talk to
+hivemind-core. HiveMind is a *gateway* around an assistant like OVOS, not a
+replacement for it.
 
-## Satellite types
+## What's a satellite, exactly?
 
-Satellites form a spectrum based on where audio processing happens. At one end the satellite does nothing but pass text; at the other it handles the complete voice stack locally.
+Satellites form a spectrum, and the only question that places a device on it is
+**where the audio is processed**. At the thin end, the device forwards raw audio and
+hivemind-core does everything. At the thick end, the device runs wake word, speech
+recognition, and speech synthesis itself, and sends hivemind-core only the final text.
 
-| Satellite | Local processing | Server requirements |
+| Satellite | Runs on the device | Runs on hivemind-core |
 |---|---|---|
-| **HiveMind-cli** | Text I/O only | Any hivemind-core |
-| **hivemind-mic-satellite** | Mic + [VAD](reference/glossary.md#ovos-voice-vocabulary) | Audio binary protocol for STT/TTS/wakeword |
-| **HiveMind-voice-relay** | Mic + VAD + Wakeword | Audio binary protocol for STT/TTS |
-| **HiveMind-voice-sat** | Mic + VAD + Wakeword + STT + TTS | Any hivemind-core (sends text utterances) |
-| **hivemind-webspeech** | Browser mic + VAD | hivemind-core listener + `allow-msg` (see page) |
-| **ESP32 / MicroPython** | Mic (and, on some boards, VAD/wakeword) | Audio binary protocol |
+| [CLI client](satellites/cli.md) | nothing (you type) | everything |
+| [WebSpeech](satellites/webspeech.md) (browser) | mic capture, VAD | speech · intents · skills |
+| [Mic satellite](satellites/mic-satellite.md) | mic, VAD | speech · intents · skills |
+| [Voice relay](satellites/voice-relay.md) | mic, VAD, wake word | speech · intents · skills |
+| [Voice satellite](satellites/voice-sat.md) | the whole voice stack | intents · skills |
 
-See [Choosing a Satellite](satellites/index.md) for a detailed comparison.
+A thin satellite is cheaper and simpler but leans on the network; a thick one keeps
+even the audio private and rides out a flaky connection. Most people start thin and
+thicken the devices that need it. See [Choosing a Satellite](satellites/index.md).
 
----
+!!! tip "Keep this open"
+    The [Glossary](reference/glossary.md) defines every term used across the manual on
+    a single page — handy on your first read.
 
-## Mesh topology
-
-HiveMind-core instances can connect to other instances, forming a hierarchy. A child instance acts as a client to its parent while being a server to its own satellites. `ESCALATE` messages travel up the chain; `BROADCAST` messages travel down. This enables multi-room or multi-household topologies where each instance controls its local devices but can route requests upward.
-
-```
-[Root hivemind-core]
-    ├──→ [Child A] ──→ satellites
-    └──→ [Child B] ──→ satellites
-```
-
-See [Nested Hives](concepts/mesh.md#nested-hives) for details.
-
----
-
-## Security model
-
-Every client authenticates with an **access key** and a **password**. After authentication the session is encrypted with an authenticated cipher — AES-256-GCM or ChaCha20-Poly1305, negotiated per connection. The key is never transmitted; both sides derive it independently via PBKDF2 from the shared password and exchanged nonces.
-
-Permissions are configured per client. The default policy admits only a basic set of message types; you expand or restrict per-client using the `hivemind-core` CLI. Skills and intents can be blacklisted individually.
-
-See [Security](concepts/security.md) for the full model.
-
----
-
-## What HiveMind is not
-
-- It is **not** a replacement for OVOS when running as a skills server. OVOS remains the AI back-end; HiveMind is the external-facing gateway.
-- It is **not** a cloud service. Everything runs on your own hardware.
-- It does **not** replace the OVOS messagebus for local communication. The messagebus remains internal.
-
----
-
-**Next:** [Quick Start](quickstart.md) to set up your first hivemind-core and satellite, or [Core Concepts](concepts/protocol.md) for how the protocol works.
+**Next:** [Quick Start](quickstart.md) — stand up hivemind-core and connect your first satellite.

--- a/docs/concepts/databases.md
+++ b/docs/concepts/databases.md
@@ -1,11 +1,16 @@
 # Database Backends
 
-**hivemind-core stores which devices may connect and what each is permitted to do in a swappable database backend.** `hivemind-core` keeps client credentials and settings there — a single file for simple setups, or a shared Redis server when you run several hivemind-core instances.
+Somewhere, hivemind-core has to remember the guest list: which devices are allowed to
+knock, what key each one holds, and what each is permitted to say once inside. For a
+home setup that's a single file sitting quietly on disk — nothing to install, nothing to
+run. Scale up to several servers sharing one guest list and that file becomes a shared
+Redis instead. Same information either way; only *where it lives* changes, and swapping
+that out never touches the rest of your setup.
 
 !!! abstract "In a nutshell"
-    - Three backends: SQLite (default for new installs), JSON (human-readable, unsafe under concurrent writes), and Redis (for multi-instance deployments).
-    - The backend is chosen in the `database` block of `~/.config/hivemind-core/server.json`, never as a CLI flag; `listen` and every client command read the same config.
-    - Migrate between backends with `migrate-db`; both file backends support encryption at rest via a `password` key.
+    - Three places to keep the guest list: **SQLite** (the default — a transactional file, nothing extra to run), **JSON** (the same idea but human-readable, and not safe if two processes write at once), and **Redis** (a shared store for when several servers need one list).
+    - You pick the backend in the `database` block of `~/.config/hivemind-core/server.json` — never a command-line flag. `listen` and every client command read that same file, so they always agree on where the list lives.
+    - Move between them with `migrate-db`, and lock either file backend at rest with a `password` key.
 
 | Backend | Module (package) | Default location | Best for |
 |---|---|---|---|

--- a/docs/concepts/databases.md
+++ b/docs/concepts/databases.md
@@ -12,6 +12,9 @@ that out never touches the rest of your setup.
     - You pick the backend in the `database` block of `~/.config/hivemind-core/server.json` — never a command-line flag. `listen` and every client command read that same file, so they always agree on where the list lives.
     - Move between them with `migrate-db`, and lock either file backend at rest with a `password` key.
 
+Three backends, and honestly most people never leave the first. Here they are side by side
+— read the "Best for" column and you'll know which one is you:
+
 | Backend | Module (package) | Default location | Best for |
 |---|---|---|---|
 | **SQLite** | `hivemind-sqlite-db-plugin` (`hivemind-sqlite-database`) | XDG data dir, e.g. `~/.local/share/hivemind-core/clients.db` | New installations (default) |
@@ -54,7 +57,10 @@ Records are copied with their full credentials and metadata; the source database
 
 ## Selecting a backend
 
-Backend selection is **not** a command-line flag — `hivemind-core listen` takes no arguments. The backend is chosen in `~/.config/hivemind-core/server.json` under the `database` block:
+Whichever you pick, you point at it the same way — and it's a config edit, never a flag
+(`hivemind-core listen` takes no arguments). Name the backend in the `database` block of
+`~/.config/hivemind-core/server.json`, with a matching sub-block for its connection
+details. Redis, for instance:
 
 ```json
 {

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -22,6 +22,10 @@ fine with an address typed in by hand — but when you want it, it's here.
 
 ## Discovery transports
 
+"Calling out on the network" isn't one fixed technique — there are a couple of ways a
+server can announce itself, and which one works depends on your network. The default
+covers almost everyone; the others are fallbacks for when it doesn't.
+
 **mDNS / Zeroconf (default)**: Standard multicast DNS service discovery. Enabled by default (`--zeroconf` defaults to `True`). Requires the optional `zeroconf` package (LGPL, imported lazily); without it, announce/scan silently fall back to UPnP only.
 
 **UPnP / SSDP (legacy, off by default)**: An SSDP server advertises a UPnP device descriptor; satellites scan for it. Supported but disabled by default (`--upnp` defaults to `False`). Useful where mDNS is unavailable.

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -1,6 +1,13 @@
 # Auto Discovery
 
-**Discovery lets satellites find hivemind-core on their own** instead of having its network address typed into every device by hand — either by listening for it on the local network, or (for first-time setup with no keyboard) by exchanging credentials through sound.
+Typing a server's IP address into a phone is tedious. Typing it into a five-dollar
+microcontroller that has no keyboard is impossible. Discovery is how a satellite finds
+hivemind-core without you reciting its address — the server calls out "I'm over here" on
+the local network, and satellites that are listening simply hear it. And for that very
+first pairing on a device with no screen and no keys, there's a trick worthy of a
+sci-fi film: hivemind-core and the satellite can hand each other credentials *through
+sound*, a short chirp played across the room. None of this is required — a hive works
+fine with an address typed in by hand — but when you want it, it's here.
 
 !!! abstract "In a nutshell"
     - Discovery is optional and provided by the separate [HiveMind-presence](https://github.com/JarbasHiveMind/HiveMind-presence) package; `hivemind-core` runs fine with a manually configured host.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,9 +1,11 @@
 # Core Concepts
 
-**This section explains how HiveMind works** — the ideas behind the mesh, not the
-commands to run it. You don't need to read it all before setting things up
-([Quick Start](../quickstart.md) gets you running in ten minutes), but a skim here
-makes every other page click into place.
+You can run HiveMind without ever reading this section — the [Quick Start](../quickstart.md)
+gets you talking to a satellite in ten minutes flat. But at some point you'll wonder
+*why* a new device can't do anything until you allow it, or *how* a question finds its
+way to the right server, or *what* actually crosses the wire. This is where those
+answers live: the ideas behind the mesh, not the commands to run it. Skim it once and
+every other page clicks into place.
 
 !!! tip "New here? Read these two first"
     Start with **[Mesh Topology](mesh.md)** (what the pieces are) and

--- a/docs/concepts/mesh.md
+++ b/docs/concepts/mesh.md
@@ -1,11 +1,17 @@
 # Mesh Topology
 
-**A HiveMind can be more than one server with devices around it.** hivemind-core instances connect to other instances, forming a tree of rooms, households, or sites, and messages travel up, down, or across that tree to reach the right place.
+Start with one server and a handful of devices and you have the whole picture most
+people ever need. But nothing says a HiveMind stops there. A server can itself connect
+*upward* to a bigger server, the way a room reports to a household and a household to a
+whole building. Give every housemate their own hivemind-core, wire them all into a
+shared one that owns the front-door lock and the living-room speakers, and you have a
+tree — questions climb toward whoever can answer them, announcements roll back down to
+whoever needs to hear. The pieces are the same as before; you've just stacked them.
 
 !!! abstract "In a nutshell"
-    - A hivemind-core instance runs the AI back-end and accepts satellite connections; a child instance is a client to its parent and a server to its own satellites.
-    - `ESCALATE` and `QUERY` travel up the tree, `BROADCAST` travels down, and `PROPAGATE`/`CASCADE` flood in all directions.
-    - Every hop re-checks its own permission ACL, so a child instance never inherits more access than the root granted it.
+    - Every hivemind-core runs the brain and accepts satellites. Stack two of them and the lower one wears two hats at once: a client to its parent, a server to its own satellites.
+    - Messages know which way to go: `ESCALATE` and `QUERY` climb toward the root, `BROADCAST` rolls down to the leaves, and `PROPAGATE`/`CASCADE` flood everywhere.
+    - Trust doesn't leak between floors — every hop re-checks its own permission list, so a child hive can never hand out more than the root gave it.
 
 ## hivemind-core and satellites
 

--- a/docs/concepts/mesh.md
+++ b/docs/concepts/mesh.md
@@ -48,13 +48,19 @@ hivemind-core instances can connect to other instances. A child instance acts as
 
 `ESCALATE` travels from a satellite up through intermediate hivemind-core instances toward the root. Use it when a node cannot handle a request locally and wants the parent to try.
 
+![ESCALATE climbs toward the root](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/escalate.gif)
+
 ### BROADCAST — downward routing
 
-`BROADCAST` travels from a master down to all connected satellites. Supports a `target_site_id` field to reach only satellites in a specific location — for example, announcing dinner is ready in the kitchen.
+`BROADCAST` travels from a hivemind-core instance down to all connected satellites. Supports a `target_site_id` field to reach only satellites in a specific location — for example, announcing dinner is ready in the kitchen.
+
+![BROADCAST rolls down to every satellite](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/broadcast.gif)
 
 ### PROPAGATE — all-directions flood
 
 `PROPAGATE` delivers a message to all connected nodes, both up and down the tree simultaneously. Useful for mesh-wide announcements and topology discovery (PING is always wrapped in PROPAGATE).
+
+![PROPAGATE floods the whole mesh](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/propagate.gif)
 
 ### QUERY — routed request with response
 

--- a/docs/concepts/mesh.md
+++ b/docs/concepts/mesh.md
@@ -15,7 +15,11 @@ whoever needs to hear. The pieces are the same as before; you've just stacked th
 
 ## hivemind-core and satellites
 
-Every HiveMind deployment has at least one **hivemind-core instance** (also called a master) and one or more **satellites** (also called clients or slaves). hivemind-core runs the AI back-end — either an OVOS skills server or a persona/LLM server — and accepts incoming connections from satellites. A satellite connects to hivemind-core, sends utterances or messages, and receives responses.
+Start with the simplest shape, the one nearly everyone runs. At the centre is a single
+**hivemind-core instance** (the protocol also calls it a *master*); around it sit one or
+more **satellites** (also called *clients* or *slaves*). hivemind-core holds the brain —
+an OVOS skills server or a persona/LLM — and waits for connections. A satellite dials in,
+sends what it heard, and gets an answer back. That's the whole loop:
 
 ```
 [Satellite A] ──┐
@@ -23,19 +27,30 @@ Every HiveMind deployment has at least one **hivemind-core instance** (also call
 [Satellite C] ───┘
 ```
 
-The protocol itself is transport-agnostic: WebSocket is the default, but HTTP, MQTT, and other transports are supported via network protocol plugins.
+Notice what the diagram *doesn't* pin down: the arrows aren't any particular wire. The
+protocol is transport-agnostic — WebSocket is the default, but HTTP, MQTT, and others plug
+in underneath without changing the picture.
 
 ---
 
 ## site_id
 
-Every satellite carries a `site_id` — a free-form string identifying its physical location (e.g. `"living-room"`, `"kitchen"`). hivemind-core injects `site_id` into OVOS message context, allowing skills to return location-aware responses. It also lets you target `BROADCAST` messages at a specific room.
+One small tag makes a satellite location-aware. Every satellite carries a `site_id` — a
+free-form label for where it physically is, like `"living-room"` or `"kitchen"`.
+hivemind-core slips that tag into the OVOS message context, so a skill can answer
+differently depending on the room, and so you can aim a `BROADCAST` at one place instead
+of the whole house. Hold onto `site_id` — it's what makes "announce dinner *in the
+kitchen*" possible a few sections from now.
 
 ---
 
 ## Nested hives
 
-hivemind-core instances can connect to other instances. A child instance acts as a client to its parent (sending `ESCALATE` up the chain) while acting as a server to its own satellites (sending `BROADCAST` down the chain). This creates a hierarchy:
+Here's where the single-server picture opens up. A hivemind-core instance doesn't only
+accept satellites — it can also become a satellite of *another* hivemind-core. When it
+does, it wears two hats at once: a client to its parent (sending `ESCALATE` up) and a
+server to its own satellites (sending `BROADCAST` down). Stack a few of those and you get
+a tree:
 
 ```
 [Root hivemind-core]
@@ -43,6 +58,10 @@ hivemind-core instances can connect to other instances. A child instance acts as
     │               └──→ [Satellite A2]
     └──→ [Child B]  ──→ [Satellite B1]
 ```
+
+Once there's a tree, a message needs to know which way to travel through it — and that's
+exactly what the routing verbs from the [Protocol](protocol.md) page are for. Each one is
+a direction of travel. Watch them move:
 
 ### ESCALATE — upward routing
 
@@ -76,9 +95,13 @@ hivemind-core instances can connect to other instances. A child instance acts as
 
 ## Relay nodes
 
-A **relay node** is a hivemind-core instance that is simultaneously connected upstream to a parent master. It serves its own downstream satellites while forwarding traffic in both directions.
+A child in the tree usually answers for itself. But sometimes you want a middle node that
+*doesn't* — one that just passes traffic through in both directions, like a repeater
+extending the hive one hop further. That's a **relay node**: a hivemind-core instance
+wired to a parent upstream and satellites downstream, forwarding between them.
 
-A relay is created by calling `HiveMindListenerProtocol.bind_upstream(slave_protocol)` after the slave is bound to a bus. Once bound:
+You create one by calling `HiveMindListenerProtocol.bind_upstream(slave_protocol)` after
+the slave is bound to a bus. From then on it fans traffic both ways:
 
 - `BROADCAST` and `PROPAGATE` from the upstream master are fanned out to all downstream clients.
 - `QUERY` and `CASCADE` from the upstream master are also fanned out downstream.
@@ -100,7 +123,11 @@ A CASCADE sent by Satellite A is forwarded to both Satellite B and up to the roo
 
 ## Permissions across nested hives
 
-Each hop enforces its own permission chain. A child instance can grant clients no more access than the root has granted the child instance. This creates a natural permission boundary: a guest instance never inherits root capabilities simply by connecting.
+Stacking servers raises a fair worry: if a guest connects to a child hive, could it reach
+past that child and command the root? No — and the reason is worth internalising. Each hop
+enforces its *own* permission chain. A child can hand its clients no more than the root
+handed the child. So capability shrinks as you go down, never grows: a guest instance
+inherits nothing just by plugging in.
 
 ??? note "Advanced: why the boundary actually holds"
     The boundary is not just a convention — it is enforced at **every hop**. A message arriving at a hivemind-core instance is checked against *that instance's* `allowed_types` ACL by `MessageTypeACLPolicy` (`HiveMind-core/hivemind_core/policy.py`) before it is forwarded onward. So when a child instance forwards a satellite's message upstream, it is itself a client of the root and is re-checked against the permissions the root granted *it*. A capability the root never granted the child instance can never be smuggled through by a downstream device.
@@ -110,6 +137,9 @@ Each hop enforces its own permission chain. A child instance can grant clients n
 ---
 
 ## Use cases
+
+That's a lot of machinery; here's what it's *for*. Three shapes people actually build,
+each leaning on a different piece of what you just read.
 
 **Multi-room home**: One root hivemind-core runs OVOS. Each room has a child instance that controls local devices. Satellites in each room connect to the child instance. Skills running on the root can BROADCAST to specific rooms.
 
@@ -128,7 +158,11 @@ Each hop enforces its own permission chain. A child instance can grant clients n
 
 ## Local hives (no network)
 
-A "local hive" is a hivemind-core instance and satellite running on the same machine. This is useful when you want separate processes communicating via the HiveMind protocol without a real network hop — for example, a skill running as a satellite that delegates some intents to another OVOS instance on the same host.
+One last shape, and it barely looks like a network at all. A "local hive" is a
+hivemind-core instance and a satellite running on the *same machine* — no real hop between
+them. Why bother? Because it lets two processes on one host talk over the HiveMind
+protocol as if they were across the room: a skill can run as a satellite and hand certain
+intents off to a second OVOS instance next door, all without a wire.
 
 ---
 

--- a/docs/concepts/nested-hives.md
+++ b/docs/concepts/nested-hives.md
@@ -1,0 +1,82 @@
+# Nested Hives
+
+Two people share a house. Each wants their own assistant — their own music, their
+own calendar, their own alarms — but they also share the lights, the thermostat, and
+the front door. Neither wants their private data leaking into the other's assistant,
+and neither wants to manage two separate copies of the smart home.
+
+A single assistant can't do this. Nested hives can: you let assistants connect to
+*other* assistants, and hand each connection exactly the permissions it should have.
+
+!!! abstract "In a nutshell"
+    - A **hive** is one hivemind-core and everything connected under it. A hive can connect to another hive as if it were an ordinary satellite — that's **nesting**.
+    - Messages between nested hives pass *through* the parent, so a child can reach the shared world without reaching its siblings directly.
+    - Each connection carries its own permissions, so the parent acts as a firewall — a guest or a child sees only what you allow.
+    - Unplug a nested hive and it's a fully independent assistant again.
+
+## A house with two minds
+
+Meet Mom and Dad. Dad's assistant is **John**; Mom's is **Jane**. Each runs its own
+hivemind-core, tied to personal things — John knows Dad's phone, his calendar, his
+favourite songs; Jane keeps Mom's playlists and alarms. Kept apart, they never mix.
+
+But the *house* has shared devices, so they stand up one more hivemind-core for the
+home and name it **George**. George owns the lights, the thermostat, the shared
+speakers. John and Jane each connect to George the same way a microphone satellite
+would — as clients.
+
+![Mom and Dad each with their own assistant](https://github.com/JarbasHiveMind/HiveMind-community-docs/assets/33701864/486d97a1-484c-42e0-a556-193cf70fe6c6)
+
+Now the shape matters. John and Jane talk **to** George, not to each other. When Dad
+says "turn on the lights," John forwards the request up to George, who owns the
+lights and acts. When Mom sets the temperature, the same thing happens through
+George. George is the shared point of control; John and Jane stay private islands
+hanging off it.
+
+![John and Jane both connect to George](https://github.com/JarbasHiveMind/HiveMind-community-docs/assets/33701864/1da8c4f5-243b-4b58-9465-e59612d5d74e)
+
+Personal data never crosses over. Dad's calendar lives on John; Mom's alarms live on
+Jane; only the messages meant for the shared house ever reach George. And the moment
+Mom and Dad decouple their hives — say they move apart — John and Jane are simply two
+independent assistants again, no untangling required.
+
+![Shared control flows through George](https://github.com/JarbasHiveMind/HiveMind-community-docs/assets/33701864/e0634651-ab97-475a-bf7e-5cef68235c40)
+
+## Guests, on your terms
+
+A friend, **Bob**, comes to stay, and he brings his own assistant. You want him to
+work the lights like everyone else — but not to place orders on your accounts or read
+anything personal.
+
+So you connect Bob's assistant to George as a client, and give *that connection* a
+narrow permission set. hivemind-core is the firewall: it lets Bob's messages through
+for the shared devices and drops everything else, per the [permissions](security.md)
+you set. Bob gets a real, useful assistant in your home; your private world stays
+sealed.
+
+![A guest assistant with limited permissions](https://github.com/JarbasHiveMind/HiveMind-community-docs/assets/33701864/ae8530d6-a465-4ae6-b556-b3f50562d810)
+
+The same trick makes a safe assistant for kids: a nested hive with a tailored,
+limited permission set — the skills and content that suit them, and nothing else.
+Every participant gets an experience shaped to them, and the boundaries are enforced
+at the connection, not left to good behaviour.
+
+![A tailored nested assistant for children](https://github.com/JarbasHiveMind/HiveMind-community-docs/assets/33701864/217b4185-7e1b-46f0-af83-b3c097ff2b5f)
+
+## Why it scales
+
+Nesting turns HiveMind from a star into a tree. A hivemind-core can be a parent to
+some hives and a child to another, so you compose small, private clusters into larger
+shared ones without any of them losing independence:
+
+- A message that a hive can't answer locally can **escalate** up to a bigger parent.
+- A message meant for many devices can **broadcast** down to the children.
+- Each edge in the tree is authenticated and permissioned on its own.
+
+That's how one household grows into a street, or one department into a company: not by
+building a bigger single brain, but by connecting many small ones and letting the
+parents decide what flows where. The routing that carries these messages up and down
+the tree is the [mesh](mesh.md); the boundaries that keep each hive private are its
+[permissions](security.md).
+
+**Next:** [Security & Permissions](security.md) — the access keys and per-connection allowlists that make the firewall real.

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -1,11 +1,17 @@
 # Plugin Architecture
 
-**HiveMind is built from interchangeable parts.** HiveMind Core is assembled from **five families** of plugins, managed by the **HiveMind Plugin Manager** (HPM), and each family is independently swappable without touching the others: how it talks to devices, which AI answers requests, how it handles audio, where it stores credentials, and how it decides what each device may do.
+hivemind-core is less a monolith than a socket board. Almost nothing about it is
+welded in place: the way it talks to devices, which AI actually answers a question, how
+it deals with raw audio, where it files the guest list, and how it decides what each
+device may do — every one of those is a part you can pull out and replace. Want the LLM
+brain instead of the skills brain? Swap one part; the satellites never notice. Want to
+store credentials in Redis instead of a file? Swap another. Five families of parts,
+one board they all plug into, and a manager that snaps the right ones in at startup.
 
 !!! abstract "In a nutshell"
-    - Five plugin families: network protocol, agent protocol, binary data handler, database, and policy.
-    - Defaults are the WebSocket + HTTP transports, the OVOS agent, the SQLite database, and the OVOS agent policy; no binary plugin loads by default.
-    - Plugins are wired up in `~/.config/hivemind-core/server.json`; installed package names may differ from the plugin (entry-point) names used in config.
+    - Five families of swappable parts: **network protocol** (how bytes arrive), **agent protocol** (who answers), **binary data handler** (raw audio), **database** (the guest list), and **policy** (who may do what).
+    - Out of the box you get the WebSocket + HTTP transports, the OVOS brain, a SQLite guest list, and the OVOS permission policy. No audio handler loads until you ask for one.
+    - You wire the parts together in `~/.config/hivemind-core/server.json`. Heads-up: the name you `pip install` isn't always the name you write in config — the package and the plugin can differ.
 
 ![HPM diagram](../hpm.png)
 

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -17,9 +17,14 @@ one board they all plug into, and a manager that snaps the right ones in at star
 
 ## Plugin categories
 
+Five families, five jobs. The tables below list what's available in each — but as you read
+them, the useful question isn't "what are all these?" so much as "which one would I swap to
+change *this*?" Each family answers exactly one such question.
+
 ### Network protocol plugins
 
-Control how HiveMind listens for and connects to satellites.
+**The question they answer: how do bytes get in and out?** These control how HiveMind
+listens for and connects to satellites.
 
 | Plugin | Transport | Default port | Status |
 |---|---|---|---|
@@ -36,7 +41,9 @@ real-time channel, not on PyPI (it pulls git-only carrier libraries).
 
 ### Agent protocol plugins
 
-Control which AI back-end handles incoming messages.
+**The question they answer: who actually thinks?** This is the one swap that changes what
+your assistant *is* — skills, an LLM, or someone else's agent — while the satellites never
+notice.
 
 | Plugin | Back-end |
 |---|---|
@@ -46,7 +53,8 @@ Control which AI back-end handles incoming messages.
 
 ### Binary data handler plugins
 
-Control how binary payloads (audio, images, files) are processed on hivemind-core.
+**The question they answer: what happens to raw audio?** This is the ear on the server —
+the piece a thin satellite leans on to have its speech transcribed.
 
 | Plugin | Function |
 |---|---|
@@ -56,7 +64,8 @@ No binary plugin is loaded by default. Install and configure one when you need s
 
 ### Database plugins
 
-Control where client credentials are stored.
+**The question they answer: where does the guest list live?** A file for one server, Redis
+when several share it.
 
 | Plugin | Backend |
 |---|---|
@@ -66,7 +75,8 @@ Control where client credentials are stored.
 
 ### Policy plugins
 
-Control admission — what each client is allowed to do. Policy plugins are loaded as an ordered **chain** (group `hivemind.policy`) and are consulted for every inbound message; they configure only via the `policy.chain` JSON block (there is no separate `module` selector like the other families).
+**The question they answer: who's allowed to do what?** Admission control — the gate every
+message passes before it reaches the agent. Policy plugins are loaded as an ordered **chain** (group `hivemind.policy`) and are consulted for every inbound message; they configure only via the `policy.chain` JSON block (there is no separate `module` selector like the other families).
 
 | Plugin | Function |
 |---|---|
@@ -78,7 +88,9 @@ The built-in `allowed_types` ACL (`MessageTypeACLPolicy`) is always force-prepen
 
 ## Configuration
 
-Plugins are wired up in `~/.config/hivemind-core/server.json`. The default configuration:
+All five families meet in one place: `server.json`. Reading the default file is the
+fastest way to see how the parts name each other — every `module` key is one part snapping
+into its socket:
 
 ```json
 {

--- a/docs/concepts/protocol.md
+++ b/docs/concepts/protocol.md
@@ -1,11 +1,18 @@
 # Protocol
 
-**The HiveMind protocol is the shared language its nodes speak.** It runs over pluggable transports, and every message on the wire is a `HiveMessage` — a JSON envelope (or binary-encoded equivalent) carrying a `msg_type` and a payload that says what kind of message it is and where it should go, so hivemind-core instances and satellites route it correctly.
+A kitchen Pi, a server in the closet, a phone on the couch, maybe a second server
+upstairs — for any of them to talk, they have to agree on two things: what a message
+*looks like*, and where it goes *next*. That agreement is the HiveMind protocol. Every
+message that crosses the wire is a single, uniform object — a `HiveMessage` — a JSON
+envelope (or its compact binary twin) stamped with a `msg_type` that says what the
+message is for and which way it should travel. The carrier underneath can be anything;
+the envelope is always the same shape, so a satellite and hivemind-core never have to
+guess.
 
 !!! abstract "In a nutshell"
-    - Every message is a `HiveMessage` with a `msg_type` from the `HiveMessageType` enum: payload messages (`BUS`, `SHARED_BUS`, `THIRDPRTY`, `BINARY`), routing messages (`ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM`, `PING`), and connection messages (`HELLO`, `HANDSHAKE`).
-    - `BUS` is the workhorse: a single-hop request/response between a satellite and the AI back-end.
-    - hivemind-core injects routing and session context into each OVOS message and uses `Message.reply()` to route replies back to the right satellite.
+    - Every message is a `HiveMessage` tagged with a `msg_type`. There are only three flavours: **payloads** that carry content (`BUS`, `SHARED_BUS`, `THIRDPRTY`, `BINARY`), **routing verbs** that steer a message up, down, or across the mesh (`ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM`, `PING`), and **connection** frames for setup (`HELLO`, `HANDSHAKE`).
+    - `BUS` is the one you'll meet most: a single hop from a satellite to the brain and back.
+    - hivemind-core tags each message with who asked and which session it belongs to, then uses `Message.reply()` to make sure the answer finds its way home to the right satellite.
 
 ## HiveMessage types
 

--- a/docs/concepts/protocol.md
+++ b/docs/concepts/protocol.md
@@ -16,11 +16,15 @@ guess.
 
 ## HiveMessage types
 
-Each message carries a `msg_type` from the `HiveMessageType` enum, defined in `hivemind_bus_client.message`.
+That `msg_type` stamp is the first thing every node reads, and it always comes from one
+list: the `HiveMessageType` enum in `hivemind_bus_client.message`. The list is long, but
+it sorts cleanly into three jobs — carry content, route content, or set up the
+connection. Meet them a group at a time.
 
 ### Payload messages
 
-These carry OVOS `Message` objects (or other application payloads) as their content.
+These are the ones with something *inside* — an OVOS `Message`, or your own application
+data. If a message is doing actual work, it's almost certainly one of these:
 
 | Type | Purpose | Direction |
 |---|---|---|
@@ -29,9 +33,14 @@ These carry OVOS `Message` objects (or other application payloads) as their cont
 | **`THIRDPRTY`** | User-defined payload, relayed opaquely | Application-defined |
 | **`BINARY`** | Raw binary data (audio, images, files) | Bidirectional |
 
+Ninety-nine percent of the time you'll be sending `BUS`. The other three are for
+special jobs — mirroring a bus, smuggling your own payload, or shipping audio.
+
 ### Transport / routing messages
 
-These wrap another `HiveMessage` as their payload and control how it is routed through the mesh.
+The next group carries nothing of its own. Each one *wraps another `HiveMessage`* and
+exists only to steer it — up the tree, down the tree, or out in every direction. Read
+the Direction column as the shape of the journey:
 
 | Type | Purpose | Direction |
 |---|---|---|
@@ -44,9 +53,16 @@ These wrap another `HiveMessage` as their payload and control how it is routed t
 | **`PING`** | Topology probe — always wrapped inside PROPAGATE | Bidirectional (via PROPAGATE) |
 | **`RENDEZVOUS`** | Reserved for rendezvous-nodes | Bidirectional |
 
+These only earn their keep once you have more than one hivemind-core — a plain
+one-server hive never needs them. The [Mesh Topology](mesh.md) page shows them in
+motion; the deep dives on `QUERY`, `CASCADE`, `INTERCOM`, and `PING` are further down
+this page.
+
 ### Connection management messages
 
-These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. You do not emit them manually.
+The last group you'll never send by hand — the library and hivemind-core exchange them
+for you before your first real message even leaves. They're listed here so you recognise
+them in a packet capture, not because you have to do anything with them:
 
 | Type | Purpose |
 |---|---|
@@ -56,6 +72,10 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 ---
 
 ## Roles
+
+A message type isn't a free-for-all: not every node may *send* every type, and not every
+node will *accept* one. hivemind-core and a satellite play different parts, so they
+subscribe to different halves of the list. Here's who does what:
 
 ### hivemind-core (listener protocol)
 
@@ -67,18 +87,36 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 - **Accepts**: `BUS`, `PROPAGATE`, `BROADCAST`, `QUERY`, `CASCADE`, `INTERCOM`
 - **Emits**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `QUERY`, `CASCADE`, `INTERCOM`
 
+Notice the asymmetry: only a satellite emits `ESCALATE` (it asks upward) and `SHARED_BUS`
+(it mirrors its own bus), and only hivemind-core emits `BROADCAST` (it commands
+downward). The verb you're allowed to send depends on which end of the connection you
+are.
+
 ---
 
 ## BUS message — the workhorse
 
-`BUS` is the standard single-hop request/response. A satellite wraps an OVOS `Message` in a `HiveMessage(HiveMessageType.BUS, ovos_message)` and sends it to hivemind-core, which:
+Everything above is scaffolding for this one message. When you ask "what's the weather?",
+a `BUS` message is what carries the question and a `BUS` message is what carries the
+answer home. It's a plain single hop: a satellite wraps an OVOS `Message` in a
+`HiveMessage(HiveMessageType.BUS, ovos_message)` and sends it to hivemind-core, which
+then walks four steps:
 
 1. Checks the client's `allowed_types` whitelist — if the OVOS message type is not allowed, the message is dropped
 2. Runs the configured policy chain (by default `OVOSAgentPolicy`) which injects per-client session data including skill/intent blacklists
 3. Injects the OVOS message into the local bus with routing context (`source`, `destination`, `peer`, `session`)
 4. Routes all OVOS replies back to the originating satellite by reading `context["destination"]`
 
-The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `destination` on every reply, so all downstream skill messages (`speak`, `intent.handled`, etc.) automatically carry the originating satellite's peer ID in `destination`. `hivemind-core` reads that field and routes each reply to the correct connection.
+Step 4 is the clever bit — how does a `speak` message that a skill emits *seconds later*
+know which satellite to go back to? The trick is `Message.reply()` (from
+`ovos-bus-client`). It swaps `source` ↔ `destination` on every reply, so every downstream
+skill message — `speak`, `intent.handled`, and the rest — automatically carries the
+originating satellite's peer ID in `destination`. hivemind-core reads that field and
+routes each reply to the right connection.
+
+The upshot for you: you send an utterance and the answer comes back to *your* device, not
+someone else's, without your ever addressing it. Two satellites can ask at the same
+moment and neither hears the other's reply. Here it is, one hop each way:
 
 ![A BUS message and its reply, one hop each way](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/bus.gif)
 
@@ -86,7 +124,11 @@ The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `des
 
 ## SHARED_BUS — passive monitoring
 
-`SHARED_BUS` lets a satellite share its own local OVOS bus with hivemind-core passively. hivemind-core observes but does not inject the messages into its own bus. Typically used by the [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind) skill.
+`BUS` is a satellite *asking* hivemind-core to do something. `SHARED_BUS` is the
+opposite posture: a satellite letting hivemind-core *watch* its own local OVOS bus,
+read-only. hivemind-core sees the traffic but never injects it into its own bus — think
+one-way mirror, not a shared room. The [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind)
+skill is the usual reason you'd reach for it.
 
 ![SHARED_BUS mirrors a satellite's local bus up to hivemind-core](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/shared_bus.gif)
 
@@ -94,7 +136,12 @@ The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `des
 
 ## INTERCOM — end-to-end encrypted peer-to-peer
 
-`INTERCOM` messages are sealed in a **hybrid envelope**: a random AES-256-GCM session key is wrapped with the **recipient node's RSA public key** (PKCS#1 OAEP) and the payload is encrypted with AES-256-GCM. The envelope carries base64 fields `encrypted_key`, `ciphertext`, `tag`, `nonce`, and `signature`. Intermediate nodes — including hivemind-core — cannot read the payload. Only the target node, which holds the corresponding RSA private key, can unwrap the session key and decrypt it. After decryption, the node verifies the sender's RSA signature (PSS over SHA-256) using the sender's public key (stored in the trust store).
+Every message so far passes *through* hivemind-core, which means hivemind-core can read
+it. `INTERCOM` is for when two nodes want to say something that even the servers relaying
+it can't overhear — a sealed letter passed hand to hand, where every courier can carry it
+but only the addressee can open it.
+
+The sealing is a **hybrid envelope**: a random AES-256-GCM session key is wrapped with the **recipient node's RSA public key** (PKCS#1 OAEP) and the payload is encrypted with AES-256-GCM. The envelope carries base64 fields `encrypted_key`, `ciphertext`, `tag`, `nonce`, and `signature`. Intermediate nodes — including hivemind-core — cannot read the payload. Only the target node, which holds the corresponding RSA private key, can unwrap the session key and decrypt it. After decryption, the node verifies the sender's RSA signature (PSS over SHA-256) using the sender's public key (stored in the trust store).
 
 `INTERCOM` is usually the payload of a transport message (`ESCALATE` or `PROPAGATE`) so it reaches its destination through the mesh. Intermediate nodes forward it without being able to read it.
 
@@ -102,7 +149,15 @@ The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `des
 
 ## Request/response — QUERY
 
-`QUERY` is like `ESCALATE`, but the node that handles the request sends a response back to the originator. It is the right tool when you need a definite answer from *one* node in the chain.
+The next three types only matter once your hive is more than one server deep — when a
+question might have to travel past the first hivemind-core to find an answer. `QUERY` is
+the first of them.
+
+Picture a guest assistant that can't answer "what's on my shared calendar?" on its own,
+so it passes the question up to the household server. `QUERY` is `ESCALATE` with a promise
+of a reply: it climbs the chain like an escalation, but the node that finally answers
+sends the response all the way back down to whoever asked. Reach for it when you need one
+definite answer from *one* node somewhere above you.
 
 **Request flow:**
 
@@ -112,7 +167,8 @@ The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `des
 
 **Response envelope:**
 
-A QUERY response is itself a `HiveMessage(HiveMessageType.QUERY, ...)` with `metadata["is_response"] = True`. The payload wraps an inner `BUS` `HiveMessage`, which in turn carries the OVOS reply `Message`. Fields in `metadata`:
+The answer needs to find its way back down to the exact node that asked, so the response
+carries a little bookkeeping. A QUERY response is itself a `HiveMessage(HiveMessageType.QUERY, ...)` with `metadata["is_response"] = True`. The payload wraps an inner `BUS` `HiveMessage`, which in turn carries the OVOS reply `Message`. The `metadata` fields are what the return trip routes on:
 
 | Field | Value |
 |---|---|
@@ -127,7 +183,11 @@ A QUERY response is itself a `HiveMessage(HiveMessageType.QUERY, ...)` with `met
 
 ## Scatter/gather — CASCADE
 
-`CASCADE` is like `PROPAGATE`, but every reachable node may answer. Use it when you want to collect responses from across the hive and pick the best one — for example, asking all nodes for their current status or broadcasting a question to all connected agents.
+`QUERY` wants *the* answer from one node. `CASCADE` wants *every* answer from everyone.
+It floods the hive like `PROPAGATE`, but every reachable node that can respond does — and
+the originator gathers the pile and picks a winner. Use it to ask the whole hive a
+question at once: "who's currently playing music?", "what's each node's status?", "which
+of you can handle this?"
 
 **Request flow:**
 
@@ -141,19 +201,36 @@ On the client side, `CascadeAggregator` buffers responses for a configurable `ca
 
 **Trust model:**
 
-Unlike QUERY (where responses come from a known upstream chain), CASCADE responses can originate from any node in the hive. The select callback is responsible for evaluating and choosing among responses that may come from untrusted nodes.
+Here's the catch worth remembering. A `QUERY` answer comes from a known node up your own
+chain; a `CASCADE` answer can come from *anywhere* in the hive, including nodes you have
+no particular reason to trust. So the select callback isn't just picking the prettiest
+reply — it's your one chance to vet who you're listening to before you act on it.
 
 ---
 
 ## PING and topology mapping
 
-`PING` is always wrapped inside a `PROPAGATE` — it floods to all reachable nodes. There is no separate reply message type: each node that receives a `PING` re-emits *its own* `PING` (carrying the same `flood_id`), flooded onward via `PROPAGATE`. Receivers deduplicate by `flood_id` so each probe is processed once. The PING payload is `{flood_id, peer, site_id, timestamp}`. `HiveMapper` in `hivemind_core.hive_map` observes these re-emitted PINGs to build a topology map of the live hive.
+Before any of the routing above can work, a node has to know what the hive even *looks
+like* — who's out there, and how many hops away. `PING` is how it finds out, and it
+works by echo rather than reply.
+
+A `PING` is always wrapped inside a `PROPAGATE`, so it floods to every reachable node.
+There's no `PONG`: each node that hears a `PING` simply re-emits *its own* `PING` carrying
+the same `flood_id`, which floods onward in turn. Receivers dedupe on `flood_id` so a
+probe is only ever processed once, and the payload each one carries is small —
+`{flood_id, peer, site_id, timestamp}`. `HiveMapper` in `hivemind_core.hive_map` sits and
+watches those echoes come back, and from the pattern it draws a live map of the whole
+hive.
 
 ---
 
 ## Session and context keys
 
-When a satellite sends a BUS message, hivemind-core injects routing metadata into `Message.context` before passing it to OVOS:
+Back down at the level of a single `BUS` message: how does hivemind-core keep two
+satellites' conversations from bleeding into each other, and enforce that a guest device
+can't invoke the skills you blacklisted for it? The answer is a bundle of metadata it
+quietly staples onto every message before handing it to OVOS. You rarely set these
+yourself, but knowing they're there explains a lot of "how did it know that?" moments:
 
 | Key | Value | Purpose |
 |---|---|---|
@@ -165,13 +242,19 @@ When a satellite sends a BUS message, hivemind-core injects routing metadata int
 | `context["session"]["blacklisted_skills"]` | List of skill IDs | Enforced by `IntentService` |
 | `context["session"]["blacklisted_intents"]` | List of intent names | Enforced by `IntentService` |
 
-After `Message.reply()` is called by OVOS, `source` and `destination` are swapped, so `destination` becomes the satellite's peer ID. `HiveMindListenerProtocol.handle_internal_mycroft()` reads this field to route the response to the correct satellite connection.
+And this is where the reply trick from the BUS section pays off: once OVOS calls
+`Message.reply()`, `source` and `destination` swap, so `destination` now holds the
+satellite's peer ID. `HiveMindListenerProtocol.handle_internal_mycroft()` reads that one
+field and the answer knows its way home.
 
 ---
 
 ## Protocol versions
 
-The hivemind-core `ProtocolVersion` enum bumps capabilities one step at a time:
+One last thing shapes every connection: not all clients are equally capable. A modern
+browser can run the newest encryption; a five-dollar chip cannot. So HiveMind doesn't
+force a single protocol on everyone — it negotiates, and the `ProtocolVersion` enum is
+the ladder it climbs, one rung of capability at a time:
 
 | Feature | ZERO (v0) | ONE (v1) | TWO (v2) | THREE (v3) |
 |---|:---:|:---:|:---:|:---:|
@@ -185,7 +268,15 @@ The hivemind-core `ProtocolVersion` enum bumps capabilities one step at a time:
 - **v2** — additionally enables binary framing.
 - **v3** — replaces the v1/v2 handshake with a **Noise** handshake (`Noise_XXpsk2_25519_ChaChaPoly_SHA256` by default), giving an always-encrypted, forward-secret session. This is the current default for capable clients. See [Security → Handshake and encryption](security.md#handshake-and-encryption).
 
-The server admits a connection only if it can negotiate at least `min_protocol_version` (config default **2**, so the oldest JSON-only / no-binary v0/v1 clients are refused by default), and advertises the highest version both sides support (`THREE` whenever the Noise primitive is available and a password is configured for the client). This `ProtocolVersion` enum is distinct from the binary-serialization `PROTOCOL_VERSION` constant in `serialization.py`.
+Two sides don't argue about this — they meet in the middle. The server admits a
+connection only if it can negotiate at least `min_protocol_version` (config default **2**,
+so the oldest JSON-only / no-binary v0/v1 clients are turned away by default), then
+advertises the highest version both sides can manage (`THREE` whenever the Noise
+primitive is available and the client has a password). The practical takeaway: a capable
+client quietly gets the strong, always-encrypted v3 session, and an ancient one is
+refused rather than silently downgraded. (One footnote to avoid confusion: this
+`ProtocolVersion` enum is a different thing from the binary-serialization
+`PROTOCOL_VERSION` constant in `serialization.py`.)
 
 !!! note "You don't negotiate v2 to send binary"
     Whether a v1/v2 connection uses binary framing is gated by the `binarize` boolean exchanged in the handshake, **not** by negotiating `ProtocolVersion.TWO` on its own. Under v3 the session is always encrypted and binary-capable. See [Protocol Spec](../developers/protocol-spec.md) for the framing and Noise details.

--- a/docs/concepts/protocol.md
+++ b/docs/concepts/protocol.md
@@ -80,11 +80,15 @@ These are handled automatically by `HiveMessageBusClient` and `hivemind-core`. Y
 
 The `Message.reply()` mechanism (from `ovos-bus-client`) swaps `source` ↔ `destination` on every reply, so all downstream skill messages (`speak`, `intent.handled`, etc.) automatically carry the originating satellite's peer ID in `destination`. `hivemind-core` reads that field and routes each reply to the correct connection.
 
+![A BUS message and its reply, one hop each way](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/bus.gif)
+
 ---
 
 ## SHARED_BUS — passive monitoring
 
 `SHARED_BUS` lets a satellite share its own local OVOS bus with hivemind-core passively. hivemind-core observes but does not inject the messages into its own bus. Typically used by the [ovos-skill-fallback-hivemind](https://github.com/JarbasHiveMind/ovos-skill-fallback-hivemind) skill.
+
+![SHARED_BUS mirrors a satellite's local bus up to hivemind-core](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/shared_bus.gif)
 
 ---
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -1,6 +1,13 @@
 # Security
 
-**Every device that joins a hive proves it knows a shared password, and all traffic is then encrypted.** hivemind-core also decides, per device, exactly which kinds of messages that device may send — and nothing is allowed until you grant it.
+Think of adding a device to your hive like handing someone a key to the house. Before
+they get in, they have to prove they hold the right key — without ever sliding it under
+the door where someone could copy it. Once they're inside, they still can't touch
+everything: a new device arrives able to do *nothing at all*, and you decide, one
+permission at a time, what it's allowed to say. And everything spoken between the device
+and the server is scrambled the moment the door closes, whether or not you ever bother
+with TLS. Those three ideas — prove the key, grant nothing by default, encrypt
+everything — are the whole security model.
 
 !!! abstract "In a nutshell"
     - The `access_key` is a non-secret identifier sent in the clear; the `password` is the only secret and is never transmitted — both sides derive the session key from it.

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -22,9 +22,15 @@ everything — are the whole security model.
 
 ---
 
+Those three layers are the map. The rest of this page walks them in order — starting with
+the credentials a device carries, then the handshake that proves them, then the
+permissions that fence in what it can do once it's in.
+
 ## Credentials: access key vs. password
 
-Every satellite is issued two things by `add-client`:
+When you run `add-client`, the device walks away with two things — and the difference
+between them is the whole game. One is a name it can shout across the room; the other is a
+secret it must never say out loud:
 
 - **`access_key`** — a **non-secret identifier**, like a username. It is sent in the clear in the WebSocket `authorization` header so hivemind-core knows *which* client is connecting. Leaking it does not compromise the hive.
 - **`password`** — the **only secret**, and it is **never transmitted**. Both sides derive the session key from it; a connecting peer that does not know the password simply fails the handshake and is disconnected. There is no password-recovery path over the wire — knowledge of the password is proven, never revealed.
@@ -35,9 +41,20 @@ Because the password is the sole secret, its strength is the security of the who
 
 ## Handshake and encryption
 
+So the password is the one secret, and it's never sent. That raises the obvious question:
+how do two machines agree on an encryption key from a password *without* one of them
+transmitting it? That's the handshake's whole job — a short back-and-forth at the start of
+every connection that leaves both sides holding the same key, while an eavesdropper who
+watched every byte learns nothing.
+
+There are two ways it can go, depending on how modern the client is. The good one first.
+
 ### Protocol v3 — the Noise handshake (current default)
 
-Protocol **v3** replaces the legacy handshake with the **[Noise Protocol Framework](https://noiseprotocol.org/)**. A v3-capable client (Noise primitive available and a password configured) negotiates an always-encrypted, forward-secret session:
+Any reasonably capable client — a laptop, a phone, a browser — gets the strong path.
+Protocol **v3** replaces the legacy handshake with the **[Noise Protocol Framework](https://noiseprotocol.org/)**, giving a session that's encrypted from the first real
+message and stays secret even if the password later leaks (forward secrecy). Here's what a
+v3-capable client (Noise primitive available, password configured) actually negotiates:
 
 - **Default suite:** `Noise_XXpsk2_25519_ChaChaPoly_SHA256` — mutual static-key authentication over X25519, per-handshake ephemeral Diffie-Hellman (forward secrecy), ChaCha20-Poly1305 AEAD, SHA-256. This is the suite browser and JavaScript clients ([HiveMind-js](https://github.com/JarbasHiveMind/HiveMind-js)) negotiate too: they pair the native Web Crypto API with the pure-JS [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) + [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) for the two primitives Web Crypto lacks (ChaCha20-Poly1305 and argon2id), giving **full cipher parity with hivemind-core** — no server-side configuration required. A `Noise_XXpsk2_25519_AESGCM_SHA256` suite is also registered as an AES-GCM alternative for minimal Web-Crypto-only peers (see the browser caveat below).
 - **PSK derivation:** the shared secret mixed into the handshake is `PSK = argon2id(password, salt = SHA-256(node_id))`. Salting with the server's `node_id` makes the PSK server-specific, so the same password on two servers yields two different PSKs. A full browser client derives this **in-browser** with `@noble/hashes` argon2id (same parameters as the server), so a password alone is enough — no provisioning and no server-side KDF change. A pre-provisioned 32-byte `psk` remains an option, and PBKDF2 remains an explicit fallback when a server advertises it.
@@ -58,7 +75,12 @@ Protocol **v3** replaces the legacy handshake with the **[Noise Protocol Framewo
 
 ### Legacy handshake (protocol v1 / v2)
 
-Older clients that cannot negotiate v3 fall back to the password (or RSA) handshake. It also establishes a shared session key without transmitting it. The password handshake uses a salted hash for proof and PBKDF2-SHA256 for the key:
+Not everything can run Noise, and HiveMind doesn't abandon those clients — it drops to an
+older but still sound handshake. It reaches the same destination (a shared key neither
+side transmitted); it just gets there by different math. The steps below are worth reading
+once even if you never implement them, because they show *why* watching the wire doesn't
+help an attacker. The password handshake proves the password with a salted hash and
+derives the key with PBKDF2-SHA256:
 
 ```
 Server → Client  HELLO        (node_id, server public key — plaintext)
@@ -76,7 +98,11 @@ The handshake works as follows:
 4. A common salt is derived: `salt = IV_client XOR IV_server`
 5. The session key is derived with PBKDF2: `key = PBKDF2-HMAC-SHA256(password, salt, 100_000 iterations)` — 256 bits
 
-After the handshake all messages are encrypted with the negotiated cipher using the derived session key. The cipher is **negotiated, not fixed**: the client offers an ordered list of ciphers it supports, the server filters that list against its own config `allowed_ciphers` (default `["CHACHA20-POLY1305", "AES-GCM"]`, with ChaCha20-Poly1305 listed first), and the server picks the client's most-preferred surviving choice. Both **ChaCha20-Poly1305** and **AES-GCM** are supported. Each message carries a unique nonce and an authentication tag. (AES-256-GCM is only the dataclass fallback used when a side offers no cipher list at all.)
+Read step 5 again and the point clicks: the key is derived from the password on *both*
+ends, but the password itself never crossed the wire — only the harmless IVs did. An
+eavesdropper who caught every packet still doesn't have the password, and without it can't
+compute the key. Once both sides hold that key, everything after the handshake is
+encrypted with the negotiated cipher. The cipher is **negotiated, not fixed**: the client offers an ordered list of ciphers it supports, the server filters that list against its own config `allowed_ciphers` (default `["CHACHA20-POLY1305", "AES-GCM"]`, with ChaCha20-Poly1305 listed first), and the server picks the client's most-preferred surviving choice. Both **ChaCha20-Poly1305** and **AES-GCM** are supported. Each message carries a unique nonce and an authentication tag. (AES-256-GCM is only the dataclass fallback used when a side offers no cipher list at all.)
 
 An alternative v0 path skips the handshake and uses a pre-shared `crypto_key` directly (the legacy `Encryption Key` printed by `add-client`). This path is kept for backward compatibility only.
 
@@ -122,7 +148,10 @@ For INTERCOM (and the signed trust checks on PROPAGATE / CASCADE), a node only a
 
 ## Identity file
 
-The identity file at `~/.config/hivemind/_identity.json` stores all credentials a satellite needs to connect:
+A satellite shouldn't have to be handed its password every time it starts up, so it keeps
+everything it needs to reconnect in one small file on disk: `~/.config/hivemind/_identity.json`.
+This is the file `hivemind-client set-identity` writes, and it's why a device can reboot
+and rejoin the hive on its own. Here's what lives in it:
 
 | Field | Description |
 |---|---|
@@ -149,11 +178,19 @@ hivemind-client set-identity \
 
 ## Permissions
 
-Permissions in HiveMind are configured per client — there are no roles. Each client has its own `allowed_types` whitelist and per-client skill/intent blacklists.
+The handshake proved *who* a device is. Now comes the second question: what is it allowed
+to *do*? This is the layer people underestimate, and it's the one that makes leaked
+credentials far less scary than they sound.
+
+HiveMind has no roles, no "admin can do everything" shortcut. Permissions are per client:
+each one carries its own `allowed_types` whitelist and its own skill/intent blacklists.
+And the default posture is refusal — a brand-new device can send *nothing* until you say
+otherwise.
 
 ### How the policy chain works
 
-For every message received from a satellite, hivemind-core runs a policy admission chain:
+Every message a satellite sends runs a little gauntlet before it reaches the agent. Two
+gates, always in this order:
 
 1. **`allowed_types` check** — the client's per-client whitelist is checked first. If the OVOS message type is not in the allowed list, the message is dropped immediately. This is fail-closed: a new client with an empty whitelist can send nothing.
 
@@ -220,7 +257,10 @@ See [Writing Plugins — Policy plugins](../developers/writing-plugins.md#5-poli
 
 ### Managing permissions via CLI
 
-The node ID is a **positional** argument (not a `--node-id` option). If omitted, the command prompts you to pick a client.
+In practice you'll do all of this from the command line, one grant at a time. The pattern
+is always the same — a verb, what you're granting, and which client — so once you've seen
+a few they all read the same way. (The node ID is a **positional** argument, not a
+`--node-id` option; leave it off and the command lets you pick a client from a list.)
 
 ```bash
 # Allow a message type
@@ -267,7 +307,10 @@ When a client is added via `add-client`, its `allowed_types` whitelist is **empt
 
 ## Transport security (TLS)
 
-TLS is **optional**. HiveMind's own handshake already encrypts and authenticates every payload (Noise on v3, negotiated AEAD on v1/v2), so a hive is fully secure over plain WebSocket. Add TLS only as defence-in-depth — chiefly to hide connection metadata from a passive network observer, or to satisfy an external requirement. `hivemind-core listen` takes no flags — TLS is configured in `~/.config/hivemind-core/server.json` under `network_protocol.hivemind-websocket-plugin`:
+Here's the thing that surprises people coming from the web world: you do **not** need
+`https://` for a HiveMind to be secure. TLS is optional. HiveMind's own handshake already
+encrypts and authenticates every payload (Noise on v3, negotiated AEAD on v1/v2), so a
+hive is fully private over plain WebSocket. Add TLS only as defence-in-depth — chiefly to hide connection metadata from a passive network observer, or to satisfy an external requirement. `hivemind-core listen` takes no flags — TLS is configured in `~/.config/hivemind-core/server.json` under `network_protocol.hivemind-websocket-plugin`:
 
 ```json
 {
@@ -290,6 +333,10 @@ TLS is **optional**. HiveMind's own handshake already encrypts and authenticates
 ---
 
 ## Security checklist
+
+Enough theory — here's what actually matters when you set one up. The list splits by where
+your hive lives, because a homelab on your own LAN and a server reachable from the open
+internet call for very different care.
 
 **Local/private networks:**
 

--- a/docs/developers/client-library.md
+++ b/docs/developers/client-library.md
@@ -39,6 +39,10 @@ pip install hivemind-bus-client
 
 ## Basic connection
 
+Everything starts with two lines: make a client, connect it. If you've already run
+`hivemind-client set-identity`, the client picks up host, port, key, and password from the
+identity file on its own — you don't pass a thing:
+
 ```python
 from hivemind_bus_client.client import HiveMessageBusClient
 
@@ -63,6 +67,10 @@ client.connect()
 
 ## Sending utterances
 
+Connected. Now say something. Sending an utterance is just wrapping an OVOS `Message` in a
+`BUS` envelope and emitting it — the same `BUS` message from the protocol page, built by
+hand:
+
 ```python
 from ovos_bus_client.message import Message
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
@@ -79,12 +87,20 @@ client.emit(msg)
 
 ## Handling responses
 
+The reply comes back asynchronously, so you don't wait on the emit — you register a
+callback and let it fire when the answer arrives. `on_mycroft` listens for a specific
+inner OVOS message type, and `speak` is the one that carries spoken text:
+
 ```python
 def handle_speak(message):
     print(f"AI says: {message.data['utterance']}")
 
 client.on_mycroft("speak", handle_speak)
 ```
+
+Send, listen, react — that's the entire loop. Everything below is refinement on top of
+these three moves: blocking instead of callbacks, binary instead of text, many nodes
+instead of one.
 
 ---
 
@@ -189,7 +205,9 @@ client.connect()
 
 ## Serialization and encryption
 
-`client.emit()` and `client.on()` handle all serialization and encryption automatically:
+You may have noticed you never once touched a cipher. That's deliberate — `client.emit()`
+and `client.on()` do the whole cryptographic dance for you, in this order, on every
+message:
 
 1. The `HiveMessage` is serialized (JSON or binary framing for protocol v1)
 2. The payload is compressed with zlib if enabled
@@ -266,8 +284,9 @@ received inner `PING` to `mapper.on_ping(ping_msg)`, and read back the discovere
 
 ## Request / response
 
-`HiveMessageBusClient` ships blocking helpers that emit a message and wait for a
-matching reply on the background thread. All take a `timeout` (seconds, default
+Callbacks are great for a UI, awkward for a script that just wants an answer *now*. For
+those, the client ships blocking helpers: emit a message, then wait on the background
+thread until the matching reply lands (or a timeout gives up). All take a `timeout` (seconds, default
 `3.0`) and return the received message or `None` on timeout.
 
 ```python
@@ -482,6 +501,9 @@ targeted at this node) are injected onto the bus. Related helpers:
 ---
 
 ## Reconnection
+
+Networks drop. Whether your client copes on its own depends entirely on which one you
+picked — and this catches people out, so it's worth stating plainly before you ship.
 
 **The sync `HiveMessageBusClient` reconnects automatically; the async and HTTP
 clients do not.** On a dropped websocket the sync client's `on_error` clears its

--- a/docs/developers/client-library.md
+++ b/docs/developers/client-library.md
@@ -1,11 +1,16 @@
 # Developer Guide — Client Library
 
-**`hivemind-bus-client` (repo: `hivemind-websocket-client`) is the primary Python library for building HiveMind clients.** It handles connection management, the PBKDF2 handshake, AES-256-GCM encryption, and serialization transparently.
+Twenty lines of Python and you're holding a conversation with your hive. That's the
+promise of `hivemind-bus-client` (the repo is named `hivemind-websocket-client`): you
+create a client, call `connect()`, and send a message — and everything gnarly underneath
+happens without you lifting a finger. The handshake, the key derivation, the
+authenticated encryption, the wire serialization: all handled. You write "what time is
+it?"; the library does the cryptography.
 
 !!! abstract "In a nutshell"
-    - Connect to hivemind-core from Python with `HiveMessageBusClient`, send/receive OVOS messages, and let the library handle the handshake, encryption, and serialization.
-    - Sync (thread-based), async (`asyncio`), and HTTP (polling) clients share the same message API; only the sync client reconnects on its own.
-    - Higher-level helpers cover blocking request/response, binary audio, topology discovery, CASCADE aggregation, end-to-end INTERCOM, and trusted-key identity.
+    - Talk to hivemind-core from Python with `HiveMessageBusClient` — send and receive OVOS messages while the library handles the handshake, encryption, and serialization for you.
+    - Three flavours share one message API: sync (thread-based), async (`asyncio`), and HTTP (polling). Only the sync client reconnects on its own.
+    - Higher-level helpers cover the things you'd otherwise hand-roll: blocking request/response, binary audio, topology discovery, CASCADE aggregation, end-to-end INTERCOM, and trusted-key identity.
 
 !!! note "Building your own client in Python?"
     This page is for writing a program that talks to a hivemind-core server. To simply *use* a satellite, see [Choosing a Satellite](../satellites/index.md) instead.

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,8 +1,11 @@
 # Developer Guide
 
-**The Developer Guide is for writing code against HiveMind** — building a custom
-satellite, embedding a client in an app, implementing a new transport or backend, or
-testing a protocol implementation.
+Off-the-shelf satellites cover a lot of ground — but sooner or later you'll want to
+build something that isn't in the box. A satellite of your own. A client tucked inside an
+app you're writing. A brand-new transport, a different brain, a policy that enforces your
+own rules. Maybe a clean-room implementation of the protocol in another language
+entirely. This is the section for that: writing code *against* HiveMind rather than just
+running it.
 
 !!! tip "Not a developer? You can skip this whole section."
     Running hivemind-core and connecting off-the-shelf satellites needs no code — see

--- a/docs/developers/protocol-spec.md
+++ b/docs/developers/protocol-spec.md
@@ -1,6 +1,12 @@
 # Protocol Specification
 
-**The HiveMind protocol is the byte-level wire format for `HiveMessage` traffic** — the message envelope, the negotiated handshake, encryption, and the optional binary framing enabled by the `binarize` capability.
+This is the page you reach for when you're writing a HiveMind client from scratch — in
+Rust, in Go, on a microcontroller, in whatever the Python and JavaScript libraries don't
+already cover — and you need to get every byte exactly right. It is the ground truth: the
+shape of the envelope, the step-by-step handshake, how the session key is derived, and
+the compact binary framing that kicks in when both sides agree to it. Nothing is
+hand-waved. Follow it literally and an independent client will reach a fully encrypted,
+session-established connection that hivemind-core accepts.
 
 !!! abstract "In a nutshell"
     - Every message is a `HiveMessage` (`msg_type`, `payload`, `context`); `BUS` messages carry OVOS `Message` objects.

--- a/docs/developers/protocol-spec.md
+++ b/docs/developers/protocol-spec.md
@@ -21,22 +21,32 @@ session-established connection that hivemind-core accepts.
 
 ## Message envelope
 
-Every HiveMind message is a `HiveMessage` with:
+Start with the shape of a single message, because everything else is a variation on it.
+No matter its type, a `HiveMessage` is only ever three fields:
 
 - `msg_type` — a `HiveMessageType` enum value (see [Protocol Concepts](../concepts/protocol.md))
 - `payload` — the message content (an OVOS `Message` object, a nested `HiveMessage`, or raw bytes)
 - `context` — optional routing metadata dict
 
+Get those three right and you can represent any message on the wire. The rest of this
+page is about the two hard parts: agreeing on encryption before you send them, and packing
+them tightly once you do.
+
 ---
 
 ## Protocol versions
 
-The hivemind-core `ProtocolVersion` enum (`ZERO`/`ONE`/`TWO`/`THREE`, in `hivemind_core/protocol.py`) is negotiated at connect time:
+The first thing two nodes settle is *which* protocol they're speaking, because it decides
+everything downstream — the handshake, the encryption, whether frames are JSON or binary.
+The `ProtocolVersion` enum (`ZERO`/`ONE`/`TWO`/`THREE`, in `hivemind_core/protocol.py`) is
+that dial, negotiated the moment a connection opens:
 
 - The server advertises `max_protocol_version` = **`THREE`** when the Noise primitive is available *and* the client has a password configured (`v3_capable`); otherwise `TWO` when `binarize` is enabled, else `ONE`. It advertises `min_protocol_version` = `max(config floor, crypto-derived minimum)`, where the config floor defaults to **`2`** (`min_protocol_version` in `server.json`). A client that cannot reach the advertised minimum is disconnected.
 - The legacy serialization-layer `PROTOCOL_VERSION` constant in `serialization.py` is `1`; that binary-framing version is distinct from this session `ProtocolVersion` and is not bumped for v3.
 
-Within the **v1/v2** (legacy handshake) family, binary framing is **not** gated behind a version bump — it is enabled purely by the `binarize` capability boolean negotiated during the handshake (see [Negotiation & defaults](#negotiation-defaults)). **v3** is a different handshake entirely (Noise), and its session is always encrypted and binary-capable.
+One subtlety trips up every first implementation, so read it before the table: within the
+**v1/v2** family, binary framing is **not** a version bump — it's switched on by the
+`binarize` boolean negotiated during the handshake (see [Negotiation & defaults](#negotiation-defaults)). **v3** is a different animal entirely (Noise), always encrypted and always binary-capable. With that in mind, here's the full ladder:
 
 | Version | Transport encoding | Key exchange | Compression |
 |---|---|---|---|
@@ -51,6 +61,11 @@ Within the **v1/v2** (legacy handshake) family, binary framing is **not** gated 
 ---
 
 ## Handshake state machine
+
+This is the heart of the page — the exact choreography that takes a fresh socket to an
+encrypted session. If you get one thing byte-for-byte right, make it this. Follow it
+literally: the field names below are lifted straight from the reference implementation, and
+hivemind-core is unforgiving about them.
 
 This section is the authoritative connection-setup sequence for the **legacy v1/v2 handshake** (password or RSA). If the server's step-2 `HANDSHAKE` includes a `noise` object and your client supports it, run the Noise (v3) handshake instead (see the [v3 note above](#protocol-versions)); otherwise take this branch. Field names are taken verbatim from the reference implementation (`hivemind_core/protocol.py` server side; `hivemind_bus_client/protocol.py` `HiveMindSlaveProtocol` client side). Implement it exactly.
 
@@ -92,6 +107,10 @@ Server                                  Client
   |  <encrypted BUS / QUERY / ... >       |   (6) encrypted
   |<====================================>|
 ```
+
+That diagram is the whole dance at a glance. The rest of this section zooms into each of
+those six frames and names every field it carries — this is the part you keep open in a
+second window while you code. Taking them in order:
 
 #### (1) Server → Client `HELLO` — `payload` fields
 
@@ -162,6 +181,10 @@ On receipt the client derives `crypto_key`:
 
 ## Negotiation & defaults
 
+The handshake left a few things "negotiated" — the encoding, the cipher, the key math.
+This section pins down exactly what those resolve to, including the two defaults that bite
+newcomers most often. Start with the sneakiest one.
+
 ### Default encoding is `JSON_HEX`, not `JSON_B64`
 
 Several helper functions (`encrypt_as_json`, `decrypt_from_json`) carry a Python default argument of `JSON_B64`, but those defaults are **never the protocol default**. The protocol default everywhere it matters is **`JSON_HEX`**:
@@ -229,7 +252,11 @@ The session key math lives in the external **`poorman_handshake`** package, not 
 
 ## Binary framing
 
-When both sides negotiate `binarize: true` in the handshake, messages are framed in a compact binary format instead of JSON. This is a per-connection capability flag, not a protocol-version increment — the wire `ProtocolVersion` remains `ONE`.
+Everything so far assumed JSON on the wire — readable, but chatty. When both sides agree
+to `binarize`, the same messages get packed into a tight bitstream instead, which is how
+raw audio rides the protocol without drowning it. (Remember: this is a per-connection flag,
+not a version bump — the wire `ProtocolVersion` stays `ONE`.) The format is a small header
+followed by the payload, and the header is bit-packed, so read the widths carefully:
 
 ### Header layout
 

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -1,6 +1,13 @@
 # Testing Guide
 
-**[`hivescope`](https://github.com/JarbasHiveMind/hivescope) is the in-process end-to-end testing library for HiveMind.** It wires `MasterNode`, `SatelliteNode`, and `RelayNode` objects together directly — no real sockets, no running servers, no network processes — and records every `HiveMessage` for inspection.
+Testing distributed software usually means standing up servers, opening sockets, and
+praying the timing lines up. [`hivescope`](https://github.com/JarbasHiveMind/hivescope)
+throws that whole ceremony out. You build a hive — a master, a couple of satellites,
+maybe a relay — as plain Python objects wired directly together in memory. No real
+sockets, no running processes, no network at all. Every `HiveMessage` that flows between
+them is recorded, so you can assert exactly what was routed where, whether an ACL held,
+and whether a session survived the trip. A whole multi-node topology becomes a fast,
+ordinary unit test.
 
 !!! abstract "In a nutshell"
     - Assemble a test topology from `MasterNode`, `SatelliteNode`, and `RelayNode` objects to validate message routing, session handling, ACL enforcement, and protocol compliance.

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -56,10 +56,15 @@ and outbound `HiveMessage`s as `RecordedMessage` entries.
 
 ---
 
+The four patterns below climb from simplest to richest — one server alone, then a
+satellite talking to it, then a crowd, then sessions. Most real tests are a remix of these
+four, so read them in order and you'll have the vocabulary for almost anything.
+
 ## Pattern A: Direct hivemind-core injection
 
-Emit an OVOS message on the master's agent bus and assert it was seen there
-(`emit_on_bus` simulates a skill response on hivemind-core).
+Start with the smallest possible hive: one master, nobody else. Emit an OVOS message on
+its agent bus and assert it landed — `emit_on_bus` stands in for a skill answering on
+hivemind-core.
 
 ```python
 from hivescope import TopologyBuilder

--- a/docs/developers/writing-plugins.md
+++ b/docs/developers/writing-plugins.md
@@ -1,6 +1,12 @@
 # Writing Plugins
 
-**HiveMind Core is assembled entirely from plugins discovered at runtime by the HiveMind Plugin Manager (HPM)** — no transport, AI backend, or database is hard-coded, so each is added by authoring a plugin. This is the developer-facing companion to the operator view in [Plugin Architecture](../concepts/plugins.md).
+Every part of hivemind-core that you might want to change is a plugin, and writing one is
+smaller than you'd expect. Want a new way for bytes to arrive, a new brain to answer
+questions, a new place to keep the guest list, a new rule about who may do what? You
+don't fork the server — you subclass one base class, implement a handful of methods, and
+register it under an entry point. The plugin manager finds it at startup and snaps it
+into place. This is the builder's-side companion to the operator view in
+[Plugin Architecture](../concepts/plugins.md).
 
 !!! abstract "In a nutshell"
     - Five plugin families cover the extension points: network protocol, agent protocol, binary data handler, database, and policy.

--- a/docs/developers/writing-plugins.md
+++ b/docs/developers/writing-plugins.md
@@ -20,10 +20,11 @@ into place. This is the builder's-side companion to the operator view in
 
 ## The plugin-manager model
 
-HPM is built on Python entry points. Each plugin family has a dedicated
-**entry-point group** and a matching **factory** in the `hivemind_plugin_manager`
-package. The groups are the values of the `HiveMindPluginTypes` enum
-(`hivemind_plugin_manager/__init__.py`):
+The whole system rides on one Python mechanism you may already know: entry points. Each
+family gets a dedicated **entry-point group** to register under and a matching **factory**
+that instantiates it. Learn this table and you've learned the shape of every plugin you'll
+ever write — the group name on the left is the string you'll put in your `pyproject.toml`,
+the base class on the right is what you'll subclass:
 
 | Family | Entry-point group | Factory | Base class |
 |---|---|---|---|
@@ -50,8 +51,10 @@ So authoring a plugin is two steps: (1) subclass the right base class and implem
 its contract, (2) register the class under the right entry-point group so
 `find_plugins` can see it. Each section below gives both.
 
-Every protocol base derives from a shared `_SubProtocol` dataclass
-(`hivemind_plugin_manager/protocols.py`) and so receives, for free:
+One convenience before the walkthrough: you're never handed an empty object. Every
+protocol base derives from a shared `_SubProtocol` dataclass
+(`hivemind_plugin_manager/protocols.py`), so whatever family you're writing, these come
+wired up for free:
 
 - `self.config` — the plugin's config dict
 - `self.hm_protocol` — the `HiveMindListenerProtocol` (hivemind-core) once wired up
@@ -60,6 +63,10 @@ Every protocol base derives from a shared `_SubProtocol` dataclass
 - `self.clients` — the connected `HiveMindClientConnection` map, via hivemind-core
 - `self.callbacks` — `ClientCallbacks` (`on_connect` / `on_disconnect` /
   `on_invalid_key` / `on_invalid_protocol`)
+
+Now the five families in turn. Each follows the identical rhythm — a base class, a small
+contract to implement, and an entry point to register — so once you've read one, the other
+four are quick.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,75 +3,106 @@
 
 ![HiveMind Logo](https://github.com/JarbasHiveMind/HiveMind-assets/raw/master/logo/hivemind-512.png)
 
-**HiveMind is an open-source protocol and platform** that connects lightweight **[satellite](reference/glossary.md#roles)** devices to a central AI server — **[hivemind-core](reference/glossary.md#roles)** — over the network. Satellites range from text-only CLI clients to full voice-capable devices. hivemind-core can run an [OpenVoiceOS](https://openvoiceos.github.io/community-docs) skills server or a standalone LLM/persona server.
+!!! warning "Pre-release software"
+    HiveMind is under active development. Expect bugs and breaking changes between releases.
+
+Run one voice assistant — or one chatbot — on a computer you already own, and let
+every other device in your home talk to it. The Raspberry Pi in the kitchen, a
+five-dollar microcontroller on the nightstand, an old phone, a browser tab on your
+laptop: each becomes a **satellite** of the same assistant. All the thinking happens
+on your server. No account, no cloud, nothing leaving your network — unplug the
+internet and it still answers.
+
+That server is **hivemind-core**. The small devices are **satellites**. HiveMind is
+the language they speak to each other.
 
 !!! abstract "In a nutshell"
-    - HiveMind moves the heavy AI work onto a central hivemind-core server so satellite devices can stay cheap and simple.
-    - Every connection is encrypted and permissioned; each client authenticates with its own access key and password.
-    - The protocol is transport- and payload-agnostic, and hivemind-core instances can chain into a mesh.
+    - **One brain, many bodies.** The assistant runs once, on hivemind-core; cheap devices connect as satellites and borrow it.
+    - **It's yours.** Self-hosted, encrypted end to end, and fully functional offline — the network never has to leave the building.
+    - **Anything can be a satellite.** A browser, a microcontroller, a phone, a Pi, a terminal — one protocol, over whatever transport you have.
 
-!!! tip "New to HiveMind?"
-    Start with the [Glossary](reference/glossary.md) — it defines every term used here
-    in one page — then follow the [Quick Start](quickstart.md). You don't need to be a
-    developer to run HiveMind.
+## Picture it
+
+You set up hivemind-core once, on a mini PC in a closet. Then you scatter satellites
+around the house:
 
 ```
-[Voice Satellite] ──┐
-[Mic Satellite]  ───┤──→ [hivemind-core] ──→ skills / LLM / intents
-[CLI Client]     ───┤
-[Browser Tab]    ───┘
+   "what's the weather?"                          "set a 10 minute timer"
+        kitchen Pi  ───────┐                 ┌─────── bedroom microcontroller
+                           │                 │
+      laptop browser ──────┤   hivemind-core ├────── your phone
+                           │  (the assistant │
+        garage CLI  ───────┘   lives here)   └─────── a friend's house, over the internet
 ```
 
-**Key properties:**
+Every satellite reaches the *same* assistant — same skills, same memory, same voice.
+Add a device by handing it a key; it joins in seconds. The microcontroller doesn't
+run speech recognition or an LLM — it can't. It just captures audio and lets
+hivemind-core do the heavy lifting, then plays back the reply. That's why a satellite
+can cost five dollars.
 
-- **Transport-agnostic** — protocol plugins handle WebSocket, HTTP, MQTT, and more; swap without changing clients
-- **Payload-agnostic** — OVOS messages by default; agent protocol plugins support other backends
-- **Encrypted by default** — authenticated encryption (AES-256-GCM or ChaCha20-Poly1305) with per-client access keys and a PBKDF2 password handshake
-- **Fine-grained ACL** — per-client allowlists for message types, skills, and intents; fail-closed
-- **Mesh-capable** — hivemind-core instances connect to other instances; ESCALATE goes up the chain, BROADCAST goes down
+And because hivemind-core runs on hardware you control, the conversation stays with
+you. There is no service to sign up for and no server on the other side of the world
+holding your recordings. Take the whole thing to a cabin with no internet — the
+satellites still talk to hivemind-core over the local network, and the assistant
+still works.
 
----
+## What can it run?
+
+hivemind-core is the mesh; the *intelligence* is a back end you choose and plug in:
+
+- an [OpenVoiceOS](https://openvoiceos.github.io/community-docs) skills server — a full,
+  private voice assistant (weather, timers, music, home control, hundreds of skills);
+- a **persona** — an LLM with a personality, for open-ended conversation;
+- or your own back end, through the agent-protocol plugins.
+
+Swap the brain without touching a single satellite. The devices never know the
+difference.
 
 ## Where to start
 
-Choose the path that fits you:
+=== "I just want to use it"
 
-=== "I want to *use* HiveMind"
-
-    You don't need to write any code. Most people start with the **voice satellite**
-    (full local voice) or the **mic satellite** (cheapest hardware).
+    You don't need to write any code.
 
     | I want to… | Go to |
     |---|---|
-    | Understand what HiveMind is, in plain terms | [About](about.md) |
+    | Understand HiveMind in plain terms | [About](about.md) |
     | Set up hivemind-core and connect my first satellite | [Quick Start](quickstart.md) |
-    | Run everything from a friendly web UI | [Admin Panel](server/admin-panel.md) |
+    | Run it all from a friendly web UI | [Admin Panel](server/admin-panel.md) |
     | Pick the right satellite for my hardware | [Choosing a Satellite](satellites/index.md) |
-    | Run HiveMind in Docker | [Docker Deployment](server/docker.md) |
-    | Just chat with an LLM (no skills) | [Persona Server](server/persona-server.md) |
-    | Integrate with Home Assistant | [Home Assistant](integrations/home-assistant.md) |
+    | Run it in Docker | [Docker Deployment](server/docker.md) |
+    | Just chat with an LLM | [Persona Server](server/persona-server.md) |
+    | Connect Home Assistant | [Home Assistant](integrations/home-assistant.md) |
     | Get unstuck | [FAQ](faq.md) · [Glossary](reference/glossary.md) |
 
-=== "I want to *build* on HiveMind"
+=== "I want to build on it"
 
-    Connect from code, implement the protocol elsewhere, or extend hivemind-core.
+    Connect from code, port the protocol elsewhere, or extend hivemind-core.
 
     | I want to… | Go to |
     |---|---|
-    | Connect to a hive from Python | [Client Library](developers/client-library.md) |
+    | Connect from Python | [Client Library](developers/client-library.md) |
     | Implement HiveMind in another language | [Protocol Specification](developers/protocol-spec.md) |
-    | Add a transport, backend, database, or policy | [Writing Plugins](developers/writing-plugins.md) |
-    | Test a satellite, hivemind-core, or whole mesh | [Testing](developers/testing.md) |
-    | Look up a CLI flag, config key, or message type | [Reference](reference/index.md) |
+    | Add a transport, back end, database, or policy | [Writing Plugins](developers/writing-plugins.md) |
+    | Test a satellite, server, or whole mesh | [Testing](developers/testing.md) |
+    | Look up a flag, config key, or message type | [Reference](reference/index.md) |
 
----
+    Under the hood: every satellite authenticates with its own key and password,
+    the session is encrypted with a modern Noise handshake (no TLS required, though
+    you can add it), and hivemind-core instances chain into a mesh — messages
+    `ESCALATE` up to a bigger brain or `BROADCAST` down to a room full of devices.
+    Start with the [Protocol Specification](developers/protocol-spec.md).
+
+!!! tip "Totally new to this?"
+    Read [About](about.md) for the plain-language tour, keep the
+    [Glossary](reference/glossary.md) open in a tab, then do the
+    [Quick Start](quickstart.md). Running HiveMind does not require being a developer.
 
 ## Community
 
-- [Matrix chat](https://matrix.to/#/#jarbashivemind:matrix.org) — news, support, and general discussion
-- [GitHub](https://github.com/JarbasHiveMind) — source code and issues
-- [YouTube channel](https://www.youtube.com/channel/UCYoV5kxp2zrH6pnoqVZpKSA/) — video guides and demos
-
----
+- [Matrix chat](https://matrix.to/#/#jarbashivemind:matrix.org) — news, support, and discussion
+- [GitHub](https://github.com/JarbasHiveMind) — source and issues
+- [YouTube](https://www.youtube.com/channel/UCYoV5kxp2zrH6pnoqVZpKSA/) — guides and demos
 
 **Next:** [Quick Start](quickstart.md) — set up hivemind-core and connect your first satellite.

--- a/docs/integrations/deltachat.md
+++ b/docs/integrations/deltachat.md
@@ -1,10 +1,12 @@
 # DeltaChat Bridge
 
-**[HiveMind-deltachat-bridge](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge)
-connects a [DeltaChat](https://delta.chat/) account to a HiveMind.** Anyone who
-emails the bot account gets their message forwarded to `hivemind-core` as an
-[utterance](../reference/glossary.md#utterance); the spoken reply comes back as
-a chat message in the same conversation.
+Here's a quietly clever one: talk to your assistant over plain email. [DeltaChat](https://delta.chat/)
+is an encrypted messenger that rides on ordinary email accounts, and this bridge gives it
+a bot on the other end. Email the bot, and your message goes to the hive; the reply
+arrives as a chat message in the same conversation. No chat server to run, no app to
+mandate — if you can send an email, you can reach your hive. It's a HiveMind satellite
+that happens to speak email, relaying [utterances](../reference/glossary.md#utterance) to
+hivemind-core.
 
 !!! abstract "In a nutshell"
     - Runs as the `hm-deltachat-bridge` console command, relaying between an email account and `hivemind-core`.

--- a/docs/integrations/hackchat.md
+++ b/docs/integrations/hackchat.md
@@ -1,10 +1,12 @@
 # HackChat
 
-**[HiveMind-HackChatBridge](https://github.com/JarbasHiveMind/HiveMind-HackChatBridge)
-relays a [hack.chat](https://hack.chat/) channel to and from a HiveMind.** Whatever
-is said in the channel is forwarded to `hivemind-core` as an
-[utterance](../reference/glossary.md#utterance), and the spoken reply is posted
-back into the same channel.
+This is the fastest bridge to try, because there's nothing to sign up for. [hack.chat](https://hack.chat/)
+is a bare-bones anonymous chat where you join a channel just by naming it — no account,
+no token, no API key. Point the bridge at a channel and a nickname, and it relays
+whatever's said there to your hive, posting the answer right back into the room. If you
+just want to *see a bridge work* in under a minute, start here: the only credentials it
+needs are your HiveMind identity. It relays [utterances](../reference/glossary.md#utterance)
+to hivemind-core like every other bridge.
 
 !!! abstract "In a nutshell"
     - Runs as the `hivemind-hackchat-bridge` console command; pick any channel name and a bot nickname.

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -1,6 +1,13 @@
 # Home Assistant Integration
 
-**[hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant) is a manual-install Home Assistant custom integration** that connects Home Assistant to an OVOS instance via HiveMind. It exposes the OVOS device as a Home Assistant entity with controls for audio playback, volume, microphone state, system power, and status sensors.
+Home Assistant runs your house; your hive runs your voice. This integration introduces
+them. Once it's installed, your OVOS device shows up in Home Assistant as a first-class
+entity — play and pause its audio, nudge the volume, mute the mic, read its status, even
+power-cycle it — right alongside your lights and thermostats. From HA's side it's just
+another device on the dashboard; underneath, every button press rides the encrypted
+HiveMind connection to the OVOS instance and back. It's a manual-install custom
+integration ([hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant)),
+added like any other from **Settings → Devices & Services**.
 
 !!! abstract "In a nutshell"
     - A `custom_components/hivemind` integration installed by hand, then added via **Settings → Devices & Services**.

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -33,7 +33,16 @@ cp -r custom_components/hivemind /config/custom_components/
 
 ## Required permissions
 
-This integration does more than send voice queries — it injects and reads bus messages at a system level. The HiveMind client used by this integration must have **admin privileges** and must be granted explicit access to the following message types.
+This is the one place this integration asks more of you than a chat bridge does — so
+here's *why* before the long lists. A bridge only needs to hear `speak`. This integration
+actually drives the device: it mutes the mic, reads whether a service is alive, changes
+the volume, controls playback. Each of those is a distinct bus message, and HiveMind's
+deny-by-default posture means you have to allow every one you want to use.
+
+You don't have to grant them all — grant the ones behind the controls you care about. The
+lists below are grouped by the OVOS service each message belongs to, so you can pick whole
+capabilities at a time (skip the OCP block if you don't need media controls, skip the PHAL
+blocks if you don't need volume or power). This client also needs the **admin** flag.
 
 ### ovos-core
 
@@ -160,7 +169,9 @@ ovos.phal.camera.open
 ovos.phal.camera.close
 ```
 
-Grant these permissions using `hivemind-core allow-msg`, passing the client node ID positionally:
+However many of those you decided you need, you grant them the same way — one
+`allow-msg` per message type, then the admin flag once at the end (the node ID goes last,
+positionally):
 
 ```bash
 hivemind-core allow-msg "speak" <id>

--- a/docs/integrations/matrix.md
+++ b/docs/integrations/matrix.md
@@ -1,6 +1,11 @@
 # Matrix Bridge
 
-**[HiveMind-matrix-bridge](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge) connects a [Matrix](https://matrix.org/) chat room to a HiveMind.** Messages posted in the room are forwarded to `hivemind-core` as utterances; responses come back as messages in the room.
+Drop your assistant into a group chat and let anyone in the room talk to it. The Matrix
+bridge logs into a [Matrix](https://matrix.org/) room as a bot, listens to what's said,
+and relays it to your hive — the reply lands back in the room as an ordinary message. To
+everyone chatting, it's just another member who happens to know the weather and can set
+timers. Behind the scenes it's a HiveMind satellite like any other, holding an access
+key and forwarding utterances to hivemind-core.
 
 !!! abstract "In a nutshell"
     - Logs into Matrix as a bot with an access token and relays room messages to `hivemind-core`.

--- a/docs/integrations/mattermost.md
+++ b/docs/integrations/mattermost.md
@@ -1,9 +1,11 @@
 # Mattermost Bridge
 
-**[HiveMind-mattermost-bridge](https://github.com/JarbasHiveMind/HiveMind_mattermost_bridge)
-connects a [Mattermost](https://mattermost.com/) team server to a HiveMind.** People
-talk to the assistant through direct messages or by mentioning the bot in a channel;
-the reply from `hivemind-core` is posted back into the same conversation.
+Put the assistant where your team already works. The Mattermost bridge joins your
+[Mattermost](https://mattermost.com/) server as a bot user: message it directly, or
+@-mention it in a channel, and the answer from your hive comes back in the same thread.
+It's the same idea as a Slack bot, but pointed at your own private assistant instead of
+someone's cloud. Like every bridge, it's a HiveMind satellite forwarding what it hears to
+hivemind-core.
 
 !!! abstract "In a nutshell"
     - Runs as the `hivemind-mattermost-bridge` console command, logging into Mattermost as a bot user account (email/login and password).

--- a/docs/integrations/media-player.md
+++ b/docs/integrations/media-player.md
@@ -1,10 +1,12 @@
 # Media Player
 
-**[hivemind-media-player](https://github.com/JarbasHiveMind/hivemind-media-player) turns
-a headless device into a network-controlled media player driven over HiveMind.**
-Remote controllers send standard [OCP](../reference/glossary.md#ocp-ovos-common-play)
-playback commands across the encrypted HiveMind connection, and this device plays the
-audio locally.
+Turn a spare Raspberry Pi or an old speaker into a networked player you drive from your
+hive. [hivemind-media-player](https://github.com/JarbasHiveMind/hivemind-media-player)
+makes a headless device do one thing well: play audio on command. Tell it — from
+anywhere in your hive — to play a track, pause, skip, or turn up, and it does the actual
+playing while you do the controlling. The commands are standard
+[OCP](../reference/glossary.md#ocp-ovos-common-play) playback messages travelling across
+the encrypted HiveMind connection; the device just listens and plays.
 
 !!! abstract "In a nutshell"
     - The `hivemind-player-protocol` package registers a `hivemind.agent.protocol` entry point exposing `HiveMindPlayerProtocol` — an agent plugin, not an OVOS skill.

--- a/docs/integrations/twitch.md
+++ b/docs/integrations/twitch.md
@@ -1,10 +1,11 @@
 # Twitch Bridge
 
-**[HiveMind-twitch-bridge](https://github.com/JarbasHiveMind/HiveMind-twitch-bridge)
-relays a [Twitch](https://www.twitch.tv/) channel's live chat to and from a
-HiveMind.** A viewer who mentions the bot in chat gets their message forwarded to `hivemind-core` as
-an [utterance](../reference/glossary.md#utterance); the reply is posted back
-into the stream chat.
+Give your stream a co-host that answers viewers. The Twitch bridge sits in your
+[Twitch](https://www.twitch.tv/) chat as a bot: when a viewer tags it, their message goes
+to your hive and the answer is posted straight back into chat, addressed to them by name.
+It only speaks when spoken to — a trigger tag keeps it quiet the rest of the time — so it
+rides along with your stream without talking over it. Under the hood it's a HiveMind
+satellite relaying [utterances](../reference/glossary.md#utterance) to hivemind-core.
 
 !!! abstract "In a nutshell"
     - Runs as the `hivemind-twitch-bridge` console command, joining chat over IRC with a channel name and a Twitch chat OAuth token.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -175,6 +175,11 @@ With hivemind-core running (Steps 0–2) and the satellite running (Step 6), spe
 
 ## Managing clients
 
+That first satellite won't be your last. Everything you do to manage the ones that follow
+happens with the same `hivemind-core` command you've already been using — listing who's
+registered, removing a device, or loosening what a client may do. A taste of the common
+ones:
+
 ```bash
 # List all registered clients
 hivemind-core list-clients

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,9 @@
 # Quick Start
 
-**This guide takes you from zero to a working hivemind-core server** with one connected satellite in under ten minutes.
+By the end of this page you'll say "hey mycroft, what time is it?" to one device and
+hear the answer come back — proof that the whole path works. It takes about ten minutes:
+stand up hivemind-core on a machine you own, hand a satellite a key, and watch it join.
+Everything after that is just adding more devices.
 
 !!! abstract "In a nutshell"
     - Install `hivemind-core` on the server, register a client with `add-client`, then connect a satellite with its access key and password.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,9 @@
 # CLI Reference
 
-**Every command and flag across the three HiveMind command-line tools**, grouped by the package that provides them.
+When you can't quite remember whether it's `--node-id` or a positional argument (it's
+positional), this is the page to keep open. Every command and flag across the three
+HiveMind command-line tools, grouped by the tool that provides them — `hivemind-core` for
+the server, `hivemind-client` for satellites, `hivemind-presence` for discovery.
 
 !!! abstract "In a nutshell"
     - `hivemind-core` — server-side management: client credentials, permissions, policy, and database.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,7 +15,10 @@ the server, `hivemind-client` for satellites, `hivemind-presence` for discovery.
 
 ## hivemind-core
 
-Server-side management commands for `hivemind-core`.
+This is the server operator's toolbox — everything you do to run the server and manage who
+may connect. The full command list first, then each command's flags below it. Two habits
+cover most of them: `add-client` mints credentials, and the `allow-*` / `blacklist-*` pairs
+tune what a client may do.
 
 ```
 Usage: hivemind-core [OPTIONS] COMMAND [ARGS]...
@@ -221,7 +224,10 @@ Usage: hivemind-core policy test API_KEY MSG_TYPE
 
 ## hivemind-client
 
-Satellite-side commands provided by `hivemind-websocket-client`.
+Where `hivemind-core` runs the server, `hivemind-client` runs on the *satellite* side —
+storing its identity, opening an interactive terminal to the hive, and firing individual
+messages by hand for testing. The one you'll use constantly is `set-identity`; the rest
+are for poking at a live hive.
 
 ```
 Usage: hivemind-client [OPTIONS] COMMAND [ARGS]...

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -17,6 +17,11 @@ out, plus the satellite identity file and the ports everything listens on.
 
 `hivemind-core` reads `~/.config/hivemind-core/server.json` at startup. `hivemind-core listen` takes no command-line flags; edit this file to change any setting.
 
+Rather than describe the blocks in the abstract, here's the entire default file first —
+what you'd get on a fresh install. Read it once top to bottom to see the shape, then the
+sections after it unpack each block key by key. Everything you can tune lives somewhere in
+here:
+
 ### Full default configuration
 
 ```json

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,9 @@
 # Configuration Reference
 
-**The complete `server.json` schema with every default value**, plus the satellite identity file and the default ports.
+One file decides how your server behaves: `~/.config/hivemind-core/server.json`. There
+are no start-up flags to hunt for — every port, every cipher, every plugin choice lives
+here. This page lays out that file in full, block by block, with every default spelled
+out, plus the satellite identity file and the ports everything listens on.
 
 !!! abstract "In a nutshell"
     - `hivemind-core` reads `~/.config/hivemind-core/server.json` at startup; `hivemind-core listen` takes no flags, so all settings live in this file.

--- a/docs/reference/message-types.md
+++ b/docs/reference/message-types.md
@@ -18,6 +18,11 @@ All message types are defined in `HiveMessageType` in `hivemind_bus_client.messa
 
 ## Quick reference
 
+If you only need to jog your memory, this table is the whole page — every type, its
+category, which way it flows, and what it's for, on one screen. Skim the Category column
+first: it groups the thirteen types into the four jobs they do, and the per-type sections
+below expand whichever one you landed on.
+
 | Type | Category | Direction | Purpose |
 |---|---|---|---|
 | `BUS` | Payload | Bidirectional | Single-hop message to/from AI back-end |
@@ -34,6 +39,10 @@ All message types are defined in `HiveMessageType` in `hivemind_bus_client.messa
 | `RENDEZVOUS` | Transport | Bidirectional | Reserved for rendezvous-nodes |
 | `HELLO` | Connection | Bidirectional | Node announcement on connect |
 | `HANDSHAKE` | Connection | Bidirectional | Cryptographic key exchange |
+
+The sections that follow take the types one at a time, roughly in order of how often
+you'll touch them — the everyday `BUS` first, the mesh-routing verbs next, and the
+connection frames you never send by hand last.
 
 ---
 

--- a/docs/reference/message-types.md
+++ b/docs/reference/message-types.md
@@ -1,6 +1,10 @@
 # HiveMessage Types Reference
 
-**A lookup table of every kind of message that travels over a HiveMind network** — what each one is for, which direction it flows, and what it carries.
+Every message crossing a hive is one of a small, fixed set of kinds — a `BUS` request, a
+`BROADCAST` rolling downhill, an `INTERCOM` sealed for a single recipient. This is the
+catalogue of all of them: what each one is for, which way it flows, and what it carries.
+When you're reading a packet capture or wiring up routing and need to know precisely what
+a `CASCADE` does, look it up here.
 
 !!! abstract "In a nutshell"
     - Message types fall into **payload** (`BUS`, `SHARED_BUS`, `THIRDPRTY`, `BINARY`), **transport** (`ESCALATE`, `BROADCAST`, `PROPAGATE`, `QUERY`, `CASCADE`, `INTERCOM`, `RENDEZVOUS`), **discovery** (`PING`), and **connection** (`HELLO`, `HANDSHAKE`) categories.

--- a/docs/satellites/cli.md
+++ b/docs/satellites/cli.md
@@ -1,12 +1,17 @@
 # HiveMind CLI
 
-**HiveMind-cli is the simplest satellite — a text-only terminal client that needs no audio hardware.** You type utterances and hivemind-core does everything; responses arrive as text.
+No microphone, no speaker, no models — just a cursor blinking in a terminal. You type a
+question, hit enter, and the answer prints back. That's the whole satellite. It's the
+thinnest possible way to reach your hive: the device does nothing but shuttle text, and
+hivemind-core carries every bit of the thinking. Which makes it perfect for the moments
+audio would only get in the way — poking at a new server over SSH, scripting a question
+into a cron job, or wiring up a headless box that has a network cable and nothing else.
 
 !!! abstract "In a nutshell"
-    - **Runs locally**: a terminal interface — no audio processing at all.
-    - **hivemind-core provides**: STT, TTS, skills, and intents; replies come back as text.
+    - **On the device:** a terminal, and not one ounce of audio processing.
+    - **On hivemind-core:** everything — STT, TTS, skills, intents. Replies come back as text.
     - Installs as the `hivemind-cli` console script (`pip install HiveMind-cli`).
-    - Ideal for testing hivemind-core instances and skills, scripting, and audio-less IoT devices.
+    - The natural choice for testing servers and skills, scripting, and audio-less IoT boxes.
 
 ---
 

--- a/docs/satellites/index.md
+++ b/docs/satellites/index.md
@@ -1,12 +1,19 @@
 # Choosing a Satellite
 
-**HiveMind satellites form a spectrum defined by where audio processing happens** — from a text-only terminal, through microcontrollers and microphones processed by hivemind-core, up to a full local voice stack. Choose the one that fits your hardware and use case.
+A satellite is whatever you talk *to* — but not every satellite carries the same load.
+At one end sits a terminal where you type and the server does absolutely everything. At
+the other sits a Raspberry Pi that hears the wake word, transcribes your speech, and
+speaks the reply all on its own, handing the server nothing but finished text. Every
+device in between is a question of one thing: **how much of the listening happens on the
+device, and how much on the server.** The thinner the satellite, the cheaper the
+hardware and the more it leans on the network. The thicker it is, the more it keeps to
+itself — even the audio stays home. This page helps you find your spot on that line.
 
 !!! abstract "In a nutshell"
-    - Satellites differ by **which stages run on the device** (mic, VAD, wakeword, STT, TTS) and **what crosses the wire** (text, raw audio, or audio after wakeword).
-    - Audio satellites need matching server support: raw-audio and base64-audio clients require `hivemind-audio-binary-protocol`; text satellites work with any hivemind-core instance.
-    - The [voice satellite](voice-sat.md) keeps all speech local and sends only text; the [mic satellite](mic-satellite.md) is the cheapest device but puts STT/TTS on hivemind-core.
-    - Use the [decision guide](#decision-guide) to map a device to its satellite.
+    - Satellites differ by **which stages run on the device** (mic, VAD, wakeword, STT, TTS) and **what actually crosses the wire** (typed text, raw audio, or audio only after the wake word fires).
+    - Anything that ships audio needs a server ready to catch it: raw-audio and base64-audio clients require `hivemind-audio-binary-protocol` on hivemind-core; text-only satellites work with any server.
+    - The [voice satellite](voice-sat.md) keeps all speech on the device and sends only text; the [mic satellite](mic-satellite.md) is the cheapest device to build but hands STT/TTS to the server.
+    - Not sure? The [decision guide](#decision-guide) maps a device to its satellite in a few questions.
 
 ---
 

--- a/docs/satellites/mic-satellite.md
+++ b/docs/satellites/mic-satellite.md
@@ -1,12 +1,19 @@
 # Microphone Satellite
 
-**The mic satellite is the thinnest software satellite: it runs only microphone capture and Voice Activity Detection (VAD) on-device.** Everything else — wakeword detection, STT, intent handling, and TTS synthesis — runs on hivemind-core.
+Take an old Raspberry Pi Zero, plug in a microphone, and let it do almost nothing but
+listen. The mic satellite runs just enough to notice *when* someone is speaking — a
+microphone and voice-activity detection — and streams that audio straight to
+hivemind-core. It doesn't even wait for a wake word; the server handles that too, along
+with the transcription, the skills, and the spoken reply. That makes it the simplest
+software satellite to run and the least demanding on the device. The trade-off is candid:
+because it forwards every scrap of detected speech, it's chatty on the network and leans
+hard on the server, so it's happiest on a small, fast home LAN.
 
 !!! abstract "In a nutshell"
-    - **Runs locally**: microphone + VAD.
-    - **hivemind-core provides**: wakeword, STT, intent processing, and TTS — requires `hivemind-audio-binary-protocol` on hivemind-core.
-    - Streams every VAD-gated voice segment to hivemind-core as binary `RAW_AUDIO`, so it is bandwidth-heavy and best suited to a small LAN homelab.
-    - For multi-user or at-scale deployments, prefer [voice-relay](voice-relay.md), which gates audio behind a local wakeword.
+    - **On the device:** a microphone and VAD. That's it.
+    - **On hivemind-core:** wakeword, STT, intents, and TTS — which means the server needs `hivemind-audio-binary-protocol` installed.
+    - It streams every VAD-gated segment of speech as binary `RAW_AUDIO`, so it's bandwidth-heavy — a good fit for a handful of devices on a homelab LAN.
+    - Serving many users or running at scale? Reach for [voice-relay](voice-relay.md) instead — it holds audio back until a local wake word fires.
 
 ---
 

--- a/docs/satellites/mic-satellite.md
+++ b/docs/satellites/mic-satellite.md
@@ -120,6 +120,10 @@ Example `mycroft.conf` excerpt:
 
 ## How audio flows
 
+It helps to trace one spoken sentence end to end. The device does only the first two
+steps; the moment there's sound, everything else happens on the server and comes back as
+audio to play:
+
 ```
 [Microphone] → [VAD] → raw audio chunks → [hivemind-core]
                                               ↓

--- a/docs/satellites/microcontrollers.md
+++ b/docs/satellites/microcontrollers.md
@@ -1,11 +1,13 @@
 # Microcontrollers (ESP32)
 
-**The microcontroller clients are the thinnest possible *hardware* satellites** — they turn a bare
-microcontroller (an ESP32, or a Raspberry Pi Pico W) into a HiveMind
-[satellite](../reference/glossary.md) without running OVOS or a full Python desktop
-on the device. The chip captures the microphone and ships audio to
-[hivemind-core](../reference/glossary.md); hivemind-core does all the speech-to-text, intents, skills,
-and text-to-speech.
+A chip the size of a postage stamp, costing a few dollars, with kilobytes of memory —
+and yet it can be a full front-end to your assistant. That's the trick these clients
+pull off. An ESP32 (or a Raspberry Pi Pico W) can't run speech recognition or an LLM,
+and it doesn't try to: it captures the microphone, ships the audio to
+[hivemind-core](../reference/glossary.md), and plays back whatever comes home. All the
+heavy lifting — transcription, intents, skills, speech — happens on the server. No OVOS,
+no Python desktop, no operating system to speak of runs on the device. This is what lets
+a satellite cost less than a cup of coffee.
 
 !!! abstract "In a nutshell"
     - Two clients: **ESP32 (C / ESP-IDF)** for maximum control and on-device wakeword, and **MicroPython** for pure-Python hacking.

--- a/docs/satellites/voice-relay.md
+++ b/docs/satellites/voice-relay.md
@@ -112,6 +112,10 @@ voice-relay reads `~/.config/mycroft/mycroft.conf`.
 
 ## How audio flows
 
+The same end-to-end trace as the mic satellite, with one decisive difference: the wake
+word sits on the device, so nothing leaves the room until it fires. Everything to the left
+of that arrow is silent and local:
+
 ```
 [Microphone] → [VAD] → [Wakeword detector]
                               ↓ (after activation)

--- a/docs/satellites/voice-relay.md
+++ b/docs/satellites/voice-relay.md
@@ -1,12 +1,19 @@
 # Voice Relay
 
-**Voice-relay runs microphone, VAD, and wakeword detection locally, then forwards audio to hivemind-core only after the wakeword triggers.** STT and TTS synthesis run on hivemind-core.
+The mic satellite forwards everything it hears; the voice relay waits to be spoken to.
+It listens for the wake word right there on the device, and only once you say it does
+any audio leave the room. Silence stays silent. That one change — a wake word on the
+device — buys you two things at once: far less traffic on the network, and the quiet
+comfort of knowing the microphone isn't shipping your kitchen conversations upstream
+between commands. Transcription and speech still happen on the server, so the relay
+needs a capable-enough board to run a wake-word engine (a Pi 3 or 4 is plenty) but
+nothing heavier.
 
 !!! abstract "In a nutshell"
-    - **Runs locally**: microphone + VAD + wakeword.
-    - **hivemind-core provides**: STT and TTS — requires `hivemind-audio-binary-protocol` on hivemind-core.
-    - Audio leaves the device only after wakeword activation, saving bandwidth and improving privacy over the [mic satellite](mic-satellite.md).
-    - STT/TTS are centrally governed by the hivemind-core operator — the "HiveMind as a service" model — so a relay cannot pick its own speech engines.
+    - **On the device:** microphone, VAD, and the wake word.
+    - **On hivemind-core:** STT and TTS — so the server needs `hivemind-audio-binary-protocol`.
+    - Audio only leaves the device after the wake word fires, saving bandwidth and keeping more to yourself than the [mic satellite](mic-satellite.md) does.
+    - The server operator owns the STT and TTS engines and voice — the "HiveMind as a service" model — so a relay can't swap in speech engines of its own.
 
 ---
 

--- a/docs/satellites/voice-sat.md
+++ b/docs/satellites/voice-sat.md
@@ -1,12 +1,20 @@
 # Voice Satellite
 
-**The voice satellite is the full-stack OVOS satellite: microphone, VAD, wakeword, and the STT/TTS plugins all run on the device.** Only the transcribed text utterance is sent to hivemind-core — never audio. Responses arrive as text and are spoken locally.
+At the thick end of the spectrum, the device does the listening *and* the hearing. The
+voice satellite runs the whole speech stack itself — microphone, wake word,
+transcription, and speech synthesis — and hands hivemind-core nothing but the finished
+sentence: plain text, never audio. The reply comes back as text and the device speaks it
+aloud on its own. Point it at local speech plugins and your voice never leaves the
+room; the connection to the server carries only words. It's the most private and the
+most connection-tolerant option — a flaky network can't garble audio that was never
+sent — in exchange for needing a board with real CPU behind it (a Pi 4, a laptop, a
+mini PC).
 
 !!! abstract "In a nutshell"
-    - **Runs locally**: microphone, VAD, wakeword, plus STT and TTS.
-    - **hivemind-core provides**: skills, intents, and reasoning — no `hivemind-audio-binary-protocol` needed.
-    - Sends only text utterances, so audio never reaches hivemind-core and STT/TTS are chosen independently of any hivemind-core config.
-    - The shipped default plugins (`ovos-stt-plugin-server` / `ovos-tts-plugin-server`) are remote HTTP services; swap in local plugins for fully on-device, offline operation.
+    - **On the device:** microphone, VAD, wake word, *and* STT + TTS.
+    - **On hivemind-core:** skills, intents, reasoning — and no `hivemind-audio-binary-protocol` required.
+    - It sends only text, so audio never reaches the server and you pick your own STT/TTS regardless of what the server runs.
+    - Heads-up: the *shipped defaults* (`ovos-stt-plugin-server` / `ovos-tts-plugin-server`) are remote HTTP services, so out of the box audio still leaves the device for transcription. Swap in local plugins for a fully on-device, offline satellite.
 
 > **Note**: STT and TTS are chosen on the satellite, but the *shipped defaults*
 > (`ovos-stt-plugin-server` / `ovos-tts-plugin-server`) are remote HTTP services

--- a/docs/satellites/voice-sat.md
+++ b/docs/satellites/voice-sat.md
@@ -101,7 +101,10 @@ All flags fall back to the identity file written by `hivemind-client set-identit
 
 ## Configuration
 
-voice-sat reads `~/.config/mycroft/mycroft.conf` (standard OVOS configuration). Override STT, TTS, VAD, and wakeword plugins there.
+Because the whole speech stack runs here, this is where you get to choose every piece of
+it — which recogniser, which voice, which wake word. It's standard OVOS configuration in
+`~/.config/mycroft/mycroft.conf`. The example below shows the shipped remote STT/TTS; to
+go fully offline, this is the block where you swap in local plugins.
 
 Example:
 

--- a/docs/satellites/webspeech.md
+++ b/docs/satellites/webspeech.md
@@ -1,12 +1,18 @@
 # WebSpeech Browser Satellite
 
-**The WebSpeech satellite is a JavaScript client that runs in any modern web browser**, capturing microphone audio in the browser and streaming it to hivemind-core for processing.
+No install, no hardware, no app store — just open a web page. The WebSpeech satellite is
+a satellite that lives entirely in a browser tab: it grabs the microphone right there in
+the page and streams what it hears to hivemind-core. Anyone you can hand a URL to can
+talk to your hive from their phone, their laptop, a borrowed computer — whatever has a
+browser. And it's no toy in the security department: the browser runs the same modern
+Noise handshake as a native client, deriving its key from the password in-page, so a
+password alone is all it takes.
 
 !!! abstract "In a nutshell"
-    - **Runs locally**: browser microphone + VAD (JavaScript, Silero via onnxruntime-web).
-    - **hivemind-core provides**: STT, TTS, skills, and intents.
-    - Ships captured audio as base64 over the bus (`recognizer_loop:b64_audio`), so hivemind-core needs `ovos-dinkum-listener >= 0.0.3a19` and `hivemind-core allow-msg "recognizer_loop:b64_audio"` — not the binary `RAW_AUDIO` protocol.
-    - Encryption defaults to the Noise v3 handshake with full parity to hivemind-core, deriving the PSK from the password in-browser; a password alone is enough.
+    - **On the device (the browser):** microphone capture and VAD (JavaScript — Silero via onnxruntime-web).
+    - **On hivemind-core:** STT, TTS, skills, and intents.
+    - It ships audio as base64 over the bus (`recognizer_loop:b64_audio`), *not* the binary `RAW_AUDIO` protocol — so the server needs `ovos-dinkum-listener >= 0.0.3a19` and a one-time `hivemind-core allow-msg "recognizer_loop:b64_audio"`.
+    - Encryption defaults to the Noise v3 handshake with full parity to hivemind-core, deriving the key from the password in-browser. A password is enough — nothing to provision.
 
 ---
 

--- a/docs/server/a2a-server.md
+++ b/docs/server/a2a-server.md
@@ -59,7 +59,8 @@ plugin and give it the URL of your A2A server:
 }
 ```
 
-Only `agent_url` is required. The configuration keys are:
+In practice you set one key and ignore the rest: point `agent_url` at your agent and
+you're done. The others are there for when you need auth, a longer timeout, or streaming:
 
 | Key           | Default | Description                                              |
 |---------------|---------|----------------------------------------------------------|

--- a/docs/server/a2a-server.md
+++ b/docs/server/a2a-server.md
@@ -5,7 +5,7 @@ crew, a hand-rolled FastAPI service — and you'd rather your satellites talk to
 than to OVOS skills. The A2A server is the bridge. hivemind-core forwards each question
 to your external agent over Google's open **Agent-to-Agent** protocol and streams the
 answer back to whoever asked. Your agent stays where it lives and keeps its own memory;
-the hive just becomes a fleet of microphones and screens in front of it.
+the hive just becomes a spread of microphones and screens in front of it.
 
 !!! abstract "In a nutshell"
     - Swaps the `agent_protocol` for `hivemind-a2a-agent-plugin`, forwarding every query to any Google A2A-compliant server.

--- a/docs/server/a2a-server.md
+++ b/docs/server/a2a-server.md
@@ -1,15 +1,16 @@
 # A2A Server
 
-**An A2A server is a regular `hivemind-core` server whose agent protocol is the
-[hivemind-a2a-agent-plugin](https://github.com/JarbasHiveMind/hivemind-a2a-agent-plugin).**
-Instead of routing utterances into a full OVOS skills stack, it forwards
-natural-language queries to an external **A2A (Agent-to-Agent)** server and streams the
-answer back — no `ovos-core` required.
+Maybe you've already built an agent — a LangChain pipeline, a Google ADK bot, a CrewAI
+crew, a hand-rolled FastAPI service — and you'd rather your satellites talk to *that*
+than to OVOS skills. The A2A server is the bridge. hivemind-core forwards each question
+to your external agent over Google's open **Agent-to-Agent** protocol and streams the
+answer back to whoever asked. Your agent stays where it lives and keeps its own memory;
+the hive just becomes a fleet of microphones and screens in front of it.
 
 !!! abstract "In a nutshell"
-    - Swaps the `agent_protocol` for `hivemind-a2a-agent-plugin`, forwarding queries to any Google A2A-compliant server.
+    - Swaps the `agent_protocol` for `hivemind-a2a-agent-plugin`, forwarding every query to any Google A2A-compliant server.
     - Only `agent_url` is required; `auth_header`, `timeout`, and `streaming` are optional.
-    - The HiveMind `session_id` maps 1-to-1 to the A2A `sessionId`, so multi-turn context lives on the A2A server.
+    - HiveMind's `session_id` maps one-to-one to the A2A `sessionId`, so the back-and-forth of a conversation is remembered on the agent's side, not here.
 
 [A2A](https://google.github.io/A2A/) is Google's open protocol for agent
 interoperability. An A2A server publishes an **agent card** at

--- a/docs/server/admin-panel.md
+++ b/docs/server/admin-panel.md
@@ -1,9 +1,12 @@
 # Admin Panel
 
-The **HiveMind Admin Panel** is a web browser dashboard for running and administering
-`hivemind-core`. It is the **easiest** way to stand up and manage a HiveMind: one command starts
-`hivemind-core` *and* opens a UI to administer it — no editing `server.json` by hand and no separate
-`hivemind-core` process to babysit.
+If editing JSON by hand and juggling CLI flags isn't your idea of a good evening, this
+is the door you want. The Admin Panel is a web dashboard for your whole hive: one
+command starts `hivemind-core` *and* opens a browser page to run it from. Pair a new
+satellite by scanning a QR code, flip a client's permissions with a toggle, install a
+plugin, watch the mesh light up on a live topology graph — all without touching
+`server.json` or babysitting a second process. It is the easiest way to stand up and
+manage a HiveMind, full stop.
 
 !!! abstract "In a nutshell"
     - One command starts `hivemind-core` in-process and serves a web UI to administer it.

--- a/docs/server/audio-binary-protocol.md
+++ b/docs/server/audio-binary-protocol.md
@@ -25,7 +25,10 @@ pip install hivemind-audio-binary-protocol
 
 ## Configuration
 
-In `~/.config/hivemind-core/server.json`, set the `binary_protocol` section:
+Turning the ear on means naming, in one place, every piece of the speech pipeline the
+server will now own: what listens for the wake word, what transcribes, what speaks, and
+what detects silence. That's the `binary_protocol` block. Each sub-key is one of those
+jobs:
 
 ```json
 {
@@ -92,6 +95,10 @@ pip install ovos-tts-plugin-server     # or any other TTS plugin
 ---
 
 ## Binary payload types
+
+Audio doesn't all arrive the same way — a continuous mic stream is a different thing from
+a single finished sentence, and a satellite signals which it's sending with a small type
+number on the binary frame. These are the ones this plugin recognises:
 
 | Value | Name | Description |
 |---|---|---|

--- a/docs/server/audio-binary-protocol.md
+++ b/docs/server/audio-binary-protocol.md
@@ -1,13 +1,17 @@
 # Audio Binary Protocol
 
-**`hivemind-audio-binary-protocol` is a binary data handler plugin for `hivemind-core`.** It enables `hivemind-core` to receive audio streams from satellites, run wakeword detection, STT, and TTS synthesis, and return synthesized audio to the satellite.
+A thin satellite — a bare microcontroller, a mic satellite, a voice relay — can capture
+sound but can't make sense of it. So it ships the raw audio to the server and asks the
+server to listen *for* it. This plugin is the ear on the server side: install it and
+hivemind-core can take an incoming audio stream, spot the wake word, transcribe the
+speech, run the skill, synthesize the reply, and send the finished audio back for the
+device to play. Without it, hivemind-core has no way to touch audio at all — which is why
+the mic satellite and voice relay simply won't work until it's in place.
 
 !!! abstract "In a nutshell"
-    - A `hivemind.binary.protocol` plugin that lets `hivemind-core` process raw audio; required for mic-satellite and voice-relay.
-    - `hivemind-core` owns the wakeword/STT/TTS/VAD plugins centrally — a satellite cannot choose the engine or voice.
-    - Access is gated by the client's access key and permissions; there is no open audio endpoint.
-
-Without this plugin, `hivemind-core` cannot process audio. It is required for mic-satellite and voice-relay.
+    - A `hivemind.binary.protocol` plugin that gives hivemind-core ears — required for the mic satellite and voice relay.
+    - The server owns the wakeword/STT/TTS/VAD engines centrally, so a satellite can't choose the engine or the voice.
+    - There's no open audio endpoint: a client still needs a valid access key and the right permissions before a single byte is processed.
 
 ---
 

--- a/docs/server/docker.md
+++ b/docs/server/docker.md
@@ -1,11 +1,16 @@
 # Docker Deployment
 
-**`hivemind-core` runs in Docker for easy deployment and isolation.**
+Prefer to keep hivemind-core boxed up — one command to start, one to stop, nothing
+scattered across your host? Docker is a clean way to run it: the server and its OVOS
+stack live in containers, and your configuration lives in a folder you mount in. The one
+habit to unlearn from other images is environment variables — hivemind-core ignores
+them entirely. Everything it needs is the `server.json` file you mount into the
+container, exactly the same file you'd edit on bare metal.
 
 !!! abstract "In a nutshell"
-    - There is no published all-in-one image; containers are built locally from the `hivemind-skills-server-docker` compose stack or based on the `smartgic/*` images.
-    - `hivemind-core` reads no environment variables — all configuration is the `server.json` file mounted into the non-root `hivemind` user's config directory.
-    - The stack uses `network_mode: host`; SQLite is the default database, with Redis for multi-instance deployments.
+    - There's no published all-in-one image — you build one locally from the `hivemind-skills-server-docker` compose stack, or base it on the `smartgic/*` images.
+    - `hivemind-core` reads **no** environment variables. All config is the `server.json` file mounted into the non-root `hivemind` user's config directory.
+    - The stack runs with `network_mode: host`. SQLite is the default guest list; add Redis when several instances share one.
 
 There is no published "all-in-one" hivemind-core image on the JarbasHiveMind
 namespace. Containers are either:

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -36,14 +36,19 @@ is for whoever **runs** it.
 
 ## How a request flows through hivemind-core
 
+Whichever flavour you pick, every question a satellite asks takes the same short journey
+through the server. Follow one utterance left to right:
+
 ```
 satellite ──▶ transport plugin ──▶ permission check ──▶ agent plugin ──▶ AI backend
  (mic, CLI)    (WebSocket/HTTP…)     (allowed? )         (OVOS/LLM/A2A)   (skills/LLM)
 ```
 
-The **transport** decides *how* bytes arrive, the **permission check** decides *whether*
-the message is allowed, and the **agent plugin** decides *who answers*. Each of those
-three is swappable — see [Plugin Architecture](../concepts/plugins.md).
+Three checkpoints, three questions: the **transport** decides *how* the bytes arrive, the
+**permission check** decides *whether* the message is allowed through, and the **agent
+plugin** decides *who answers* it. What makes hivemind-core hivemind-core is that all
+three are swappable parts, not fixed wiring — which is the whole story of
+[Plugin Architecture](../concepts/plugins.md).
 
 ---
 

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -1,8 +1,10 @@
 # hivemind-core Server
 
-**`hivemind-core`** is the central brain of a HiveMind. It accepts connections from
-satellites, decides what AI backend answers them, and enforces who is allowed to do
-what. This section is for whoever **runs** the server.
+Everything in a HiveMind points back to one machine: the server in the closet, on the
+desk, in the container. hivemind-core is what accepts every satellite's connection,
+decides which AI actually answers, and holds the line on who's allowed to do what. The
+satellites are interchangeable; this is the piece that makes them a hive. This section
+is for whoever **runs** it.
 
 !!! tip "Which server do I want?"
     A server's "personality" is set by one choice: **which agent plugin answers

--- a/docs/server/operations.md
+++ b/docs/server/operations.md
@@ -1,9 +1,11 @@
 # Operations
 
-**This page covers running `hivemind-core` in production** — TLS, reverse-proxy,
-service-management, observability, and scaling concerns for an operator. Everything here
-is driven by `~/.config/hivemind-core/server.json` and standard system tooling;
-`hivemind-core listen` takes no command-line flags.
+Getting a hive running is the easy part; keeping one up, encrypted, and observable while
+real people lean on it is the day-2 job. This page is the operator's toolkit — turning on
+TLS, tucking hivemind-core behind a reverse proxy, running it as a managed service,
+watching who connects and who gets turned away, and growing past a single instance. None
+of it needs special flags: `hivemind-core listen` takes none. It's all
+`~/.config/hivemind-core/server.json` and the ordinary system tooling you already know.
 
 !!! abstract "In a nutshell"
     - TLS is configured per network protocol in `server.json`, or terminated at a reverse proxy in front of `hivemind-core`.

--- a/docs/server/ovos-server.md
+++ b/docs/server/ovos-server.md
@@ -1,11 +1,16 @@
 # OVOS Skills Server
 
-**The OVOS Skills Server is the canonical `hivemind-core` setup**, backed by an OpenVoiceOS instance. Satellites connect to it and route utterances to OVOS skills, STT, and TTS.
+This is the setup that turns your hive into a real voice assistant — weather, timers,
+music, home control, hundreds of skills. Behind hivemind-core sits a full
+[OpenVoiceOS](https://openvoiceos.github.io/community-docs) install, and every satellite
+that connects gets the whole thing: ask any of them a question and an OVOS skill answers.
+It's the default flavour, and the one most people want when they picture "a private
+smart speaker I actually own." hivemind-core is the gateway; OVOS is the brain behind it.
 
 !!! abstract "In a nutshell"
-    - A `hivemind-core` server whose agent protocol talks to a local `ovos-core` / `ovos-messagebus` on `127.0.0.1:8181`.
-    - All settings live in `~/.config/hivemind-core/server.json`; `hivemind-core listen` takes no flags.
-    - Manage satellites with the `hivemind-core` client CLI (node IDs are positional).
+    - A `hivemind-core` server whose agent talks to a local `ovos-core` / `ovos-messagebus` on `127.0.0.1:8181`.
+    - Every setting lives in `~/.config/hivemind-core/server.json` — `hivemind-core listen` takes no flags.
+    - Manage satellites with the `hivemind-core` CLI (node IDs are positional).
 
 ---
 

--- a/docs/server/ovos-server.md
+++ b/docs/server/ovos-server.md
@@ -38,7 +38,10 @@ pip install hivemind-core
 
 All server configuration lives at `~/.config/hivemind-core/server.json`. `hivemind-core listen` takes no command-line flags — edit the file to change any setting. Run `hivemind-core print-config` to dump the effective configuration.
 
-Default configuration (abbreviated):
+Don't be daunted by the block below — for a standard OVOS server you barely touch it. It's
+printed in full so you can see the defaults, but the one line that matters for this setup
+is the `agent_protocol` block pointing at your OVOS messagebus. Everything else already
+does the right thing:
 
 ```json
 {
@@ -160,7 +163,10 @@ Then configure `server.json` to enable it. See [Audio Binary Protocol](audio-bin
 
 ## Systemd service
 
-To run `hivemind-core` as a system service:
+Once it works from the terminal, you'll want it to come back on its own after a reboot.
+The unit below does that — the one detail worth copying carefully is the ordering: OVOS's
+messagebus has to be up before hivemind-core tries to reach it, which the `After=` /
+`Requires=` lines guarantee.
 
 ```ini
 # /etc/systemd/system/hivemind-core.service

--- a/docs/server/persona-server.md
+++ b/docs/server/persona-server.md
@@ -39,8 +39,9 @@ This provides the `ovos-solver-openai-plugin` solver.
 
 ## Configure the persona
 
-An `ovos-persona` persona is a JSON document listing the solver(s) and their config.
-Save it somewhere (for example `~/.config/ovos_persona/persona.json`):
+A persona is just a small JSON file — a name and a list of "solvers," where a solver is
+whatever actually produces the answer (usually an LLM). Here's the whole thing for an
+OpenAI-compatible backend; save it somewhere like `~/.config/ovos_persona/persona.json`:
 
 ```json
 {
@@ -129,6 +130,10 @@ Any `ovos-solver-*` plugin can back the persona. Common ones:
 ---
 
 ## Example personas
+
+The persona file is where you decide *who* your assistant talks to. Swapping from a cloud
+model to one running on your own machine is a one-line change — the `api_url`. Two ends of
+that spectrum:
 
 **Local LLM via LocalAI / Ollama** (same OpenAI solver, pointed at a local `api_url`):
 

--- a/docs/server/persona-server.md
+++ b/docs/server/persona-server.md
@@ -1,14 +1,17 @@
 # Persona Server
 
-**A persona server is a regular `hivemind-core` server whose agent protocol is the
-[ovos-persona](https://github.com/OpenVoiceOS/ovos-persona) plugin.** Instead of routing
-utterances into a full OVOS skills stack, it answers natural-language queries
-directly from an LLM / chatbot / solver-chain persona — no `ovos-core` required.
+Sometimes you don't want timers and weather skills — you just want to *talk to
+something*. A persona server is the simplest hive there is: swap the skills brain for an
+LLM with a personality, and every satellite becomes a way to chat with it. No
+`ovos-core`, no messagebus, no skill stack to stand up — just hivemind-core, a persona,
+and whatever language model you point it at (OpenAI, a local Ollama, anything
+OpenAI-shaped). Answers stream back sentence by sentence, so the satellite can start
+speaking before the model has finished thinking.
 
 !!! abstract "In a nutshell"
-    - Swaps the `agent_protocol` for `hivemind-persona-agent-plugin`, so `hivemind-core` answers queries from an LLM / solver chain.
-    - The persona is a JSON document listing solver plugins (e.g. `ovos-solver-openai-plugin`) and their config.
-    - Text-based satellites and bridges work against it; audio-binary-protocol satellites do not.
+    - Swaps the `agent_protocol` for `hivemind-persona-agent-plugin`, so `hivemind-core` answers from an LLM / solver chain instead of skills.
+    - A persona is just a JSON document naming the solver plugins (e.g. `ovos-solver-openai-plugin`) and their config.
+    - Text satellites and bridges work against it; audio-binary-protocol satellites don't apply — a persona serves words, not server-side audio.
 
 Satellites built for `hivemind-core` (text-based ones like HiveMind-cli, voice-sat, or
 bridges) work against a persona server. Satellites that depend on the audio binary

--- a/docs/server/transports.md
+++ b/docs/server/transports.md
@@ -21,9 +21,10 @@ why, for almost everyone, this page ends at one word: WebSocket.
 
 ## Status at a glance
 
-Transports register under the `hivemind.network.protocol`
-[plugin](../concepts/plugins.md) entry-point group. They differ a lot in maturity —
-read the **PyPI status** column before you build on one:
+Four roads exist, but they are not equally paved. Before you fall for a clever one, read
+the **PyPI status** column — it's the difference between "ship it" and "fun to read
+about." All four register under the same `hivemind.network.protocol`
+[plugin](../concepts/plugins.md) entry-point group:
 
 | Transport | Package | Entry point (`hivemind.network.protocol`) | PyPI status | Notes |
 |---|---|---|---|---|

--- a/docs/server/transports.md
+++ b/docs/server/transports.md
@@ -1,10 +1,11 @@
 # Transports
 
-**A transport is how bytes travel between a satellite and `hivemind-core`.** WebSocket is the
-default; the others suit special cases. The important part: the
-[encryption](../concepts/security.md) and the message format are **identical across all
-of them** — only the carrier changes. A satellite and `hivemind-core` agree on a transport, but
-what they send over it is the same encrypted HiveMind protocol either way.
+Think of a transport as the road the message drives on, not the message itself. A
+satellite and hivemind-core have to agree on *a* road — a WebSocket, an HTTP request, an
+MQTT broker — but the cargo riding on it is the same encrypted HiveMind protocol no
+matter which they pick. Swap the road and the [encryption](../concepts/security.md) and
+message format don't change a bit; the carrier only ever sees sealed envelopes. Which is
+why, for almost everyone, this page ends at one word: WebSocket.
 
 !!! abstract "In a nutshell"
     - Transports register under the `hivemind.network.protocol` plugin entry-point group; the carrier is swappable without touching encryption or the message format.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Core Concepts:
     - concepts/index.md
     - Mesh Topology: concepts/mesh.md
+    - Nested Hives: concepts/nested-hives.md
     - Protocol & Message Types: concepts/protocol.md
     - Security & Permissions: concepts/security.md
     - Database Backends: concepts/databases.md


### PR DESCRIPTION
Rewrites the manual to read well for both a total newcomer and an advanced developer: every page opens with a concrete 'why' scenario and shows what HiveMind uniquely enables, with narrative woven between the technical blocks and full developer depth kept intact. Restores the Nested Hives concept page and the animated message-flow diagrams (bus/escalate/broadcast/propagate/shared_bus) dropped in the prior rewrite. Timeless, standalone, no meta-commentary; hivemind-core (never 'hub'). mkdocs build --strict green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)