### PR TITLE
docs: document enforced protocol floor, fail-closed INTERCOM, and loop suppression

### DIFF
--- a/docs/concepts/mesh.md
+++ b/docs/concepts/mesh.md
@@ -81,6 +81,10 @@ a direction of travel. Watch them move:
 
 ![PROPAGATE floods the whole mesh](https://raw.githubusercontent.com/JarbasHiveMind/HiveMind-core/dev/resources/propagate.gif)
 
+A flood in a mesh with a cycle would circle forever, so every forwarding node leaves a mark. Before it forwards a `PROPAGATE`, `ESCALATE`, `CASCADE`, or `PING`, the node appends a hop naming itself to the message `route`, keyed on the node's public key. If a message arrives whose route already names the node, the node does not forward it again and the flood dies there.
+
+This stops the forwarding only. A node named in the route still handles the message locally, so callbacks, local bus delivery, and PING mapping all still run. It withholds the onward fan-out and the upstream forward.
+
 ### QUERY — routed request with response
 
 `QUERY` travels upward like `ESCALATE`, but expects a response back. Each node in the chain attempts to answer from its local agent; the first node that can answer returns a response routed back downstream to the originator. If no node can answer, the root returns a `hive.query.timeout` error response.

--- a/docs/concepts/protocol.md
+++ b/docs/concepts/protocol.md
@@ -145,6 +145,10 @@ The sealing is a **hybrid envelope**: a random AES-256-GCM session key is wrappe
 
 `INTERCOM` is usually the payload of a transport message (`ESCALATE` or `PROPAGATE`) so it reaches its destination through the mesh. Intermediate nodes forward it without being able to read it.
 
+The target checks the origin before it acts on the content. It drops the message when the signature does not verify, when there is no signature, and when it holds no public key for the originator. A dropped message stops there: the node does not pass it to its peers and does not escalate it upstream.
+
+A plaintext `INTERCOM` payload proves nothing about who sent it, so a node that requires crypto drops that too. That is the default. See [Bootstrapping satellite-to-satellite trust](security.md#bootstrapping-satellite-to-satellite-trust) for the key-pinning rules and the `require_crypto=False` escape hatch.
+
 ---
 
 ## Request/response — QUERY

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -110,6 +110,8 @@ An alternative v0 path skips the handshake and uses a pre-shared `crypto_key` di
 
 The server will only admit a client that can negotiate at least `min_protocol_version` (config key in `~/.config/hivemind-core/server.json`, **default `2`**). At the default, the oldest JSON-only / no-binary **v0 and v1** clients are refused outright; a v2 client still connects with the legacy binary+handshake path, and a v3 client gets the Noise session. Raise the floor to `3` to require Noise from every client. The `ProtocolVersion` enum is `ZERO`/`ONE` (handshake) / `TWO` (binary) / `THREE` (Noise).
 
+The floor is enforced twice. The server advertises it at connect time. It checks again when the handshake completes, and it judges the version the client actually performed, not the version the client said it supports. A client that can speak v3 but sends a v2 password handshake against a floor of `3` is refused. Earlier releases let that client in and ignored the raised floor. At the default floor of `2` the same rule refuses a legacy v1 pubkey handshake.
+
 ### Weak-password refusal
 
 Because the password is the only secret and its verifier is offline-crackable, `poorman_handshake` **refuses guessable passwords** (`WeakPasswordError`). It estimates guess-resistance with [zxcvbn](https://github.com/dropbox/zxcvbn) and rejects anything below `min_password_bits` (default **40 bits** — enough to reject `Password123!`, `correct_password`, or the xkcd `Tr0ub4dour&3`, while real passphrases pass).
@@ -142,7 +144,17 @@ Reset the RSA key at any time with `hivemind-client reset-pgp` (the command name
 
 #### Bootstrapping satellite-to-satellite trust
 
-For INTERCOM (and the signed trust checks on PROPAGATE / CASCADE), a node only accepts messages from peers whose public key it has been told to trust. That trust is configured out of band: each node maintains a `trusted_keys` mapping (alias → public-key string) in its identity file. Add a peer's key with `NodeIdentity.add_trusted_key(alias, pubkey)` (and `trusted_keys` / `remove_trusted_key` to read or revoke). After PING discovery has mapped the network, `HiveMapper.mark_trusted_nodes(trusted_keys)` flips each discovered node's `trusted` flag based on that mapping, so subsequent source-trust checks resolve quickly. Keys must be exchanged through a channel you already trust — there is no automatic key acceptance.
+For INTERCOM (and the signed trust checks on PROPAGATE / CASCADE), a node only accepts messages from peers whose public key it holds. There are two ways a key gets there.
+
+**Out of band, on the client.** Each node keeps a `trusted_keys` mapping (alias → public-key string) in its identity file. Add a peer's key with `NodeIdentity.add_trusted_key(alias, pubkey)` (and `trusted_keys` / `remove_trusted_key` to read or revoke). After PING discovery has mapped the network, `HiveMapper.mark_trusted_nodes(trusted_keys)` flips each discovered node's `trusted` flag based on that mapping, so later source-trust checks resolve quickly. Exchange these keys through a channel you already trust.
+
+**Trust on first use, on the server.** hivemind-core reads the public key a client sends in its `HELLO`. It pins that key against the client's access key, in `trusted_pubkeys` (`hivemind_core/protocol.py`). INTERCOM signature checks use the pin. A later `HELLO` presenting a different key does not move an existing pin, and the server logs the mismatch.
+
+A `HELLO` only asserts a public key. It does not prove the sender holds the matching private key. So the first party to connect with an access credential owns its pin. Treat the credential as the thing that must stay secret, and pin keys out of band when you cannot control who connects first.
+
+**Verification is fail-closed.** The target node checks the origin signature on an INTERCOM before it does anything with the content. It rejects the message when the signature does not verify, when the payload carries no signature, and when no pinned key exists for the originator. It no longer processes an unverifiable INTERCOM for the sake of confidentiality alone. A rejected message stops at the node that rejected it. That node does not fan it out to peers and does not escalate it upstream.
+
+**Plaintext INTERCOM needs `require_crypto=False`.** An INTERCOM payload that is not a signed, encrypted envelope carries no origin proof at all. A node with `require_crypto` set drops it. `require_crypto` is an attribute of `HiveMindListenerProtocol` and it is `True` by default, so a stock server drops plaintext INTERCOM. If you rely on that feature, construct the listener protocol with `require_crypto=False`.
 
 ---
 
@@ -359,7 +371,8 @@ internet call for very different care.
 
 - Security is proportional to password entropy. Weak passwords are the primary attack surface — which is why `poorman_handshake` refuses guessable ones (see [Weak-password refusal](#weak-password-refusal)).
 - Without TLS, a network observer can see the encrypted ciphertext and connection metadata but not payload content. TLS adds metadata-hiding defence-in-depth; it is not required for confidentiality.
-- INTERCOM authentication requires both nodes to have pre-exchanged public keys through a trusted channel.
+- INTERCOM authentication needs the receiver to hold the sender's public key, either exchanged through a trusted channel or pinned from the sender's first `HELLO`. A message it cannot verify is dropped, not delivered.
+- A pin taken from a `HELLO` is only as good as the access credential that carried it. The first party to connect with that credential owns the pin.
 
 ---
 

--- a/docs/developers/protocol-spec.md
+++ b/docs/developers/protocol-spec.md
@@ -41,7 +41,7 @@ everything downstream — the handshake, the encryption, whether frames are JSON
 The `ProtocolVersion` enum (`ZERO`/`ONE`/`TWO`/`THREE`, in `hivemind_core/protocol.py`) is
 that dial, negotiated the moment a connection opens:
 
-- The server advertises `max_protocol_version` = **`THREE`** when the Noise primitive is available *and* the client has a password configured (`v3_capable`); otherwise `TWO` when `binarize` is enabled, else `ONE`. It advertises `min_protocol_version` = `max(config floor, crypto-derived minimum)`, where the config floor defaults to **`2`** (`min_protocol_version` in `server.json`). A client that cannot reach the advertised minimum is disconnected.
+- The server advertises `max_protocol_version` = **`THREE`** when the Noise primitive is available *and* the client has a password configured (`v3_capable`); otherwise `TWO` when `binarize` is enabled, else `ONE`. It advertises `min_protocol_version` = `max(config floor, crypto-derived minimum)`, where the config floor defaults to **`2`** (`min_protocol_version` in `server.json`). A client that cannot reach the advertised minimum is disconnected. The server also checks the floor a second time, when the handshake completes, against the version the client actually performed. A client that declares v3 capability but sends a v1 or v2 handshake envelope below the floor is disconnected before the legacy path runs.
 - The legacy serialization-layer `PROTOCOL_VERSION` constant in `serialization.py` is `1`; that binary-framing version is distinct from this session `ProtocolVersion` and is not bumped for v3.
 
 One subtlety trips up every first implementation, so read it before the table: within the
@@ -293,7 +293,9 @@ Followed by: metadata bytes, then payload bytes. To pad to a byte boundary, zero
 | 11 | THIRDPRTY |
 | 12 | BINARY |
 
-`INTERCOM` has no dedicated binary integer slot — it defaults to `11` when encoded. The type field is a 5-bit unsigned integer.
+The type field is a 5-bit unsigned integer. Codes `0`-`12` are assigned with no gaps and no reserved values. Codes `13`-`31` are unassigned: a sender must not emit them, and a receiver rejects such a frame as malformed instead of mapping it to a type.
+
+`INTERCOM` has no code of its own. The encoder falls back to `11` for any type it cannot map, so a binary-framed `INTERCOM` arrives at the far end as `THIRDPRTY`. Send `INTERCOM` as a text frame to keep its type.
 
 ### Binary payload type
 
@@ -397,5 +399,5 @@ high-latency covert/fallback control-plane, not a real-time transport.
 Validated against the HiveMind source:
 
 - [`hivemind_bus_client/serialization.py`](https://github.com/JarbasHiveMind/hivemind-websocket-client/blob/HEAD/hivemind_bus_client/serialization.py) — `PROTOCOL_VERSION`, the binary framing encoder/decoder, the `_INT2TYPE` message-type table
-- [`hivemind_bus_client/message.py`](https://github.com/JarbasHiveMind/hivemind-websocket-client/blob/HEAD/hivemind_bus_client/message.py) — `HiveMessageType`, `HiveMessage.as_dict`, the `INTERCOM`-defaults-to-`11` encoding
+- [`hivemind_bus_client/message.py`](https://github.com/JarbasHiveMind/hivemind-websocket-client/blob/HEAD/hivemind_bus_client/message.py) — `HiveMessageType`, `HiveMessage.as_dict`
 - [`hivemind_core/protocol.py`](https://github.com/JarbasHiveMind/HiveMind-core/blob/HEAD/hivemind_core/protocol.py) — `ProtocolVersion`, `max_protocol_version`, the server-side handshake state machine and capability defaults

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -125,6 +125,15 @@
     4. Make sure the client is **allowed** — a brand-new client is denied every message type
        until you run `hivemind-core allow-msg ...` (see [Security](concepts/security.md#permissions)).
 
+??? question "INTERCOM messages stopped arriving after an upgrade"
+    A node now drops an `INTERCOM` it cannot attribute to a sender. Check three things.
+    First, the payload must be a signed, encrypted envelope. A stock server requires crypto
+    and drops a plaintext `INTERCOM`. Second, the receiver must hold the sender's public key,
+    either added out of band or pinned from the sender's first `HELLO`. Third, the signature
+    must verify against that key. To keep sending plaintext `INTERCOM`, construct the listener
+    protocol with `require_crypto=False`. See
+    [Bootstrapping satellite-to-satellite trust](concepts/security.md#bootstrapping-satellite-to-satellite-trust).
+
 ??? question "How do I find the server's address automatically?"
     Run `hivemind-presence scan` on the same network (hivemind-core announces itself when auto
     discovery is enabled). Most satellites also auto-scan when you start them without a

--- a/docs/reference/message-types.md
+++ b/docs/reference/message-types.md
@@ -159,6 +159,10 @@ End-to-end encrypted point-to-point message.
 - **Signature**: sender's RSA private key signs (PSS over SHA-256)
 - **Routing**: typically wrapped in ESCALATE or PROPAGATE to reach the target
 - **Intermediate nodes**: cannot read the content or determine the recipient
+- **Origin check**: the target verifies the signature against the sender's pinned public key. A bad signature, a missing signature, or an unknown originator means the message is dropped
+- **A dropped message is not relayed**: it goes no further to peers and is not escalated upstream
+- **Plaintext payloads**: a node with `require_crypto` (the default) drops an `INTERCOM` that is not a signed envelope. Set `require_crypto=False` to keep plaintext `INTERCOM` working
+- **Binary framing**: `INTERCOM` has no 5-bit type code, so a binary frame carries it as `THIRDPRTY` (`11`)
 
 ---
 


### PR DESCRIPTION
Documents behavior already merged and released upstream. Every claim was checked against `origin/dev` of HiveMind-core and hivemind-websocket-client.

| Change | Upstream |
|---|---|
| The server checks `min_protocol_version` again when the handshake completes, judging the version the client actually performed. A v3-capable client that sends a v2 password envelope against a floor of 3 is refused. At the default floor of 2 a legacy v1 pubkey handshake is refused. | HiveMind-core #165 |
| INTERCOM origin verification is fail-closed: no pinned key, no signature, or a signature that does not verify means the frame is dropped. A rejected frame stops at the node that rejected it and is not fanned out or escalated. | HiveMind-core #166 |
| A node with `require_crypto` (the default) drops a plaintext INTERCOM, because such a payload carries no origin proof. `require_crypto=False` keeps the plaintext feature working. | HiveMind-core #169 |
| Mesh flooding terminates: a forwarding node appends a hop naming itself to `route`, keyed on its public key, and does not re-forward a message whose route already names it. Local handling still runs. | HiveMind-core #162 |
| Binary type codes 0-12 are assigned with no gaps. Codes 13-31 are unassigned and a receiver rejects such a frame as malformed. | hivemind-bus-client #145 |
| Trust bootstrapping now describes both mechanisms: the out-of-band `trusted_keys` mapping on the client and the trust-on-first-use pin taken from a peer's `HELLO` into `trusted_pubkeys` on the server, where a later HELLO cannot move an existing pin. States the caveat that a HELLO asserts a public key without proving possession. | HiveMind-core #166 |

## Files

- `docs/concepts/security.md` - protocol floor enforcement, trust bootstrapping rewrite, fail-closed INTERCOM, plaintext INTERCOM, limitations
- `docs/concepts/protocol.md` - INTERCOM origin check and drop rules
- `docs/concepts/mesh.md` - loop suppression under PROPAGATE
- `docs/developers/protocol-spec.md` - handshake-time floor check, binary type-code registry
- `docs/reference/message-types.md` - INTERCOM reference bullets
- `docs/faq.md` - troubleshooting entry for INTERCOM that stopped arriving

## Correction to note

The spec page said `INTERCOM` "defaults to `11` when encoded". The encoder still does exactly that: `_INT2TYPE` has no INTERCOM entry and `typemap.get(hive_type, 11)` falls back to `11`, so a binary-framed INTERCOM arrives as `THIRDPRTY`. Only the decoder changed in #145. The page now says this plainly and advises text framing for INTERCOM.

## Checks

- `mkdocs build --strict` passes
- ASD-STE100 lint: every changed file scores lower (better) than its baseline on `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `INTERCOM` security requirements, including signature verification, trusted keys, encrypted envelopes, and plaintext handling.
  * Documented minimum protocol-version enforcement during and after handshakes.
  * Explained cycle prevention during message propagation.
  * Added details on binary message-type codes and `INTERCOM` framing.
  * Added troubleshooting guidance and trust-on-first-use behavior to the FAQ and security documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->