### PR TITLE
docs: sync protocol behaviour with the shipped fixes

### DIFF
--- a/docs/03_pairing.md
+++ b/docs/03_pairing.md
@@ -82,7 +82,11 @@ Workflow:
 
 ## The Identity File
 
-The identity file stores the credentials and settings a node needs to connect and communicate within the HiveMind network. It lets the node authenticate and keep secure connections with other nodes.
+A node has one identity: one PGP keypair, one Noise static key, and one set of pinned peer keys, used in both directions — serving its own clients and dialing its master. The identity file stores that identity plus the settings a node needs to connect and communicate within the HiveMind network.
+
+Credentials (access key, password), the `useragent` and `site_id` are not part of that identity. They say how to reach one particular master, so a node that both serves clients and connects upstream holds its own credentials as well as its master's. A client reads credentials from the identity file only as a fallback, when none were passed explicitly, and never writes them back to it — connecting to a master never overwrites the node's own name or credentials.
+
+If a node has no keypair yet, one is generated and persisted automatically the first time it is needed. An unwritable config directory does not stop the node from starting; it just cannot generate or keep a keypair, so it answers PING anonymously and cannot be mapped (see [node identity below](#public-key)).
 
 Connection parameters can be set at launch time, but this file lets you reuse them across the whole OS.
 
@@ -90,16 +94,19 @@ Connection parameters can be set at launch time, but this file lets you reuse th
 
 The identity file is usually at `~/.config/hivemind/_identity.json` and contains:
 
-| Field           | Description                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------|
-| `name`          | A human-readable label for the node, not guaranteed to be unique.                            |
-| `password`      | The password used to generate a session AES key for secure communication within the HiveMind network. |
-| `access_key`    | A unique access key assigned to the node for identification and authentication.              |
-| `site_id`       | An identifier for the physical location or context where the node operates.                  |
-| `default_port`  | The default port number used to connect to the HiveMind core.                                |
-| `default_master`| The default host (address) of the HiveMind core the node connects to.                        |
-| `public_key`    | The ASCII-encoded public PGP key used to authenticate the node within the HiveMind network.  |
-| `secret_key`    | The path to the private PGP key file, which uniquely identifies the node and proves its identity. |
+| Field                | Description                                                                                  |
+|----------------------|------------------------------------------------------------------------------------------------|
+| `name`               | A human-readable label for the node, not guaranteed to be unique.                            |
+| `password`           | The password used to generate a session AES key for secure communication within the HiveMind network. |
+| `access_key`         | A unique access key assigned to the node for identification and authentication.              |
+| `site_id`            | An identifier for the physical location or context where the node operates.                  |
+| `default_port`       | The default port number used to connect to the HiveMind core.                                |
+| `default_master`     | The default host (address) of the HiveMind core the node connects to.                        |
+| `public_key`         | The ASCII-encoded public PGP key used to authenticate the node within the HiveMind network.  |
+| `secret_key`         | The path to the private PGP key file, which uniquely identifies the node and proves its identity. |
+| `noise_key`          | The path to the static X25519 private key used by the protocol-v3 Noise handshake. Generated and persisted on first use so key pinning survives a restart. |
+| `pinned_noise_keys`  | Trust-on-first-use store of peer node id → Noise static public key. A later handshake whose key contradicts the pin is a fatal authentication failure. |
+| `trusted_keys`       | Alias → public key mapping of peers this node trusts for `INTERCOM`, `PROPAGATE` and `CASCADE` origin verification. |
 
 By keeping these details in the identity file, nodes can join the HiveMind network securely and efficiently.
 
@@ -114,6 +121,7 @@ The public key in the identity file is part of a PGP key pair that uniquely iden
 1. **Unique node identification**: the PGP key uniquely identifies this node within the HiveMind network.
 2. **Inter-node authentication**: nodes use the PGP key to authenticate each other, so only authorized nodes can communicate within the network.
 3. **Network independence**: the PGP key lets nodes identify each other regardless of the specific HiveMind core (mind) they connect to. Even if a node switches minds, it still recognizes and authenticates other nodes by their PGP keys.
+4. **Addressing and mapping**: the public key is the node's address for `INTERCOM` messages, its entry on a hive map, and its hop for loop suppression when a message is relayed across the mesh. A node with no public key answers `PING` anonymously and cannot be mapped.
 
 #### Private key
 

--- a/docs/04_protocol.md
+++ b/docs/04_protocol.md
@@ -8,13 +8,13 @@ The protocol has two main roles: the Listener Protocol and the Client Protocol.
 
 ### Listener Protocol
 
-- **Accepts**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `INTERCOM`
-- **Emits**: `BUS`, `PROPAGATE`, `BROADCAST`, `INTERCOM`
+- **Accepts**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `INTERCOM`, `QUERY`, `CASCADE`, `RENDEZVOUS`
+- **Emits**: `BUS`, `PROPAGATE`, `BROADCAST`, `INTERCOM`, `QUERY`, `CASCADE`, `RENDEZVOUS`
 
 ### Client Protocol
 
-- **Accepts**: `BUS`, `PROPAGATE`, `BROADCAST`, `INTERCOM`
-- **Emits**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `INTERCOM`
+- **Accepts**: `BUS`, `PROPAGATE`, `BROADCAST`, `INTERCOM`, `QUERY`, `CASCADE`, `RENDEZVOUS`
+- **Emits**: `BUS`, `SHARED_BUS`, `PROPAGATE`, `ESCALATE`, `INTERCOM`, `QUERY`, `CASCADE`, `RENDEZVOUS`
 
 ### Permissions
 
@@ -97,7 +97,7 @@ Options:
 
 ### INTERCOM message
 
-Messages can also be encrypted with a node's [public key](03_pairing.md#the-identity-file). This stops intermediate nodes from reading the message contents.
+INTERCOM is the end-to-end encrypted peer-to-peer channel. Messages are encrypted with a node's [public key](03_pairing.md#the-identity-file), so intermediate nodes cannot read the contents, and only the intended recipient can decrypt them.
 
 An encrypted message is a regular hive message, but has the type `"INTERCOM"` and payload `{"ciphertext": "XXXXXXX"}`.
 
@@ -109,9 +109,13 @@ These messages usually appear as the payload of transport messages such as `ESCA
 
 To send a message securely, HiveMind encrypts it with the recipient node's public PGP key. Only the intended recipient, holding the matching private PGP key, can decrypt it.
 
-After encryption, HiveMind signs the message with the sender's private PGP key. This authenticates the sender and confirms the message was not tampered with.
+After encryption, HiveMind signs the message with the sender's private PGP key.
 
-When a node receives an encrypted message, it tries to decrypt it with its private PGP key. If decryption succeeds, the node processes and emits the payload internally.
+#### Origin authentication
+
+A receiving node verifies that signature against a key in its own [trusted keys](03_pairing.md#contents-of-the-identity-file), with its master's public key acting as a trust anchor. A frame with no pinned or trusted key for the sender, no signature, or a signature that fails verification is dropped: it is never decrypted, dispatched, relayed to peers, or escalated upstream.
+
+This stops an outsider from injecting a message onto a node's bus by knowing its public key — the key is public by design, published in every `PING` answer, so knowing it was never meant to be enough on its own. The guarantee has a limit worth stating plainly: it stops an outsider, but it does not stop one trusted peer claiming to be another trusted peer.
 
 You must know the target node's public key beforehand to send it a secret message.
 
@@ -196,6 +200,28 @@ Options:
   --payload TEXT   ovos message.data json
   --help           Show this message and exit.
 ```
+
+### QUERY message
+
+- **Purpose**: ask a specific peer a question and get a response routed back, without flooding the whole mesh.
+- **Permission**: sending a `QUERY` requires `can_escalate`.
+- **Behavior**:
+    - The response is a frame carrying `{"is_response": true, "originator_peer": <peer>}` in its metadata, so a relaying node can route it straight back instead of flooding it.
+    - The permission check runs before a frame claiming to be a response is routed, so a client without `can_escalate` cannot forge `is_response`/`originator_peer` to deliver arbitrary content to another peer.
+    - Routing trusts the sender's own `originator_peer`. A sender that does have `can_escalate` can still address a response to a peer for a query it never took part in — the check stops an unprivileged client from forging a response, it does not verify the response actually answers the query it claims to.
+
+### CASCADE message
+
+- **Purpose**: like `QUERY`, but collects responses from multiple peers down a fan-out instead of a single target.
+- **Permission**: sending a `CASCADE` requires `can_propagate`.
+- **Behavior**: same routing and permission-ordering guarantees, and the same limit, as `QUERY` above.
+
+### RENDEZVOUS message
+
+- **Purpose**: store-and-forward mailbox for peers that are not connected to the same node at the same time.
+- **Behavior**:
+    - The node serving the mailbox answers with `mailbox_node`, naming itself, on every path — including refusals.
+    - Mail is held per node: two peers attached to different nodes still exchange nothing through `RENDEZVOUS`. With `mailbox_node` in the answer, a client can at least tell that is what happened, instead of a silent empty mailbox.
 
 ---
 

--- a/docs/12_handshake.md
+++ b/docs/12_handshake.md
@@ -149,6 +149,10 @@ This protects all data exchanged between the server and client, even if a third 
 
   - HiveMind logs messages that do not follow the protocol, and may terminate the connection.
 
+**Malformed frames**:
+
+  - Every inbound frame has its route stamped with the receiving node's hop before the message type is dispatched and before any authentication. A route entry is only trusted when it is a dict carrying a `source`; anything else is treated as absent rather than raising, so a malformed first frame from an unauthenticated peer cannot crash the connection.
+
 **Authentication failures**:
 
   - Authentication failures end the handshake and reject the connection.

--- a/docs/16_permissions.md
+++ b/docs/16_permissions.md
@@ -8,9 +8,13 @@ HiveMind's permission system gives fine-grained control over access to resources
 
 2. One predefined role: admin. A client may be marked admin with `--admin true`, or with `make-admin` and `revoke-admin` later. Admin grants the reserved `default` session and the right to originate `BROADCAST`, and only while `can_broadcast` is not revoked. It does not exempt a client from `allowed_types`.
 
-3. **Fine-grained access control**: Permissions are not just "allowed" or "denied." You can configure access at a fine-grained level, down to individual bus messages, skills, and intents.
+3. **Routing permissions**: `can_broadcast`, `can_escalate` and `can_propagate` gate a client's right to originate `BROADCAST`, [`QUERY`](04_protocol.md#query-message)/`ESCALATE`, and [`CASCADE`](04_protocol.md#cascade-message)/`PROPAGATE` respectively. They are set with the `allow-broadcast`, `allow-escalate` and `allow-propagate` commands (and their `blacklist-` counterparts). For `QUERY` and `CASCADE`, this check runs before a frame claiming to be a response is routed, so a client without the matching permission cannot forge a response and deliver arbitrary content to another peer. See [Response routing](04_protocol.md#query-message) for the limit of that guarantee.
 
-4. **Emergent roles**: HiveMind has no formal roles, but roles can emerge from client-specific configuration. A client with broad access can function like an "admin," while another client with limited access can serve as a "guest." These roles are not predefined; they follow from each client's permission settings.
+4. **HTTP and WebSocket parity**: `can_broadcast`, `intent_blacklist` and `skill_blacklist` from a client's record apply the same way over the HTTP transport as over WebSocket. See [Network Plugins](network_plugins.md).
+
+5. **Fine-grained access control**: Permissions are not just "allowed" or "denied." You can configure access at a fine-grained level, down to individual bus messages, skills, and intents.
+
+6. **Emergent roles**: HiveMind has no formal roles, but roles can emerge from client-specific configuration. A client with broad access can function like an "admin," while another client with limited access can serve as a "guest." These roles are not predefined; they follow from each client's permission settings.
 
 ### Comparison to traditional RBAC
 

--- a/docs/network_plugins.md
+++ b/docs/network_plugins.md
@@ -33,6 +33,7 @@ Each HiveMind node loads one network plugin, which defines how it connects to th
   - WebSockets are blocked or unavailable.
   - a simpler one-off communication model is enough.
 - Less efficient for real-time streaming, but useful for constrained networks or integrations.
+- Applies the same per-client restrictions as the WebSocket plugin: `can_broadcast`, `intent_blacklist` and `skill_blacklist` from the client record are enforced identically over both transports. See [Permissions](16_permissions.md).
 
 ---
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Brings the community docs in line with a batch of protocol fixes landing across the ecosystem right now. I checked every claim against current source before writing it, and tried to be plain about what each security guarantee does not cover, not just what it does.

The pairing page listed only the PGP keypair as part of a node's identity. Added the noise key, pinned noise keys, trusted keys, the one-identity-per-node model where credentials are read as a fallback and never written back, and the fact that a node generates its own keypair automatically now. The protocol page said INTERCOM signing "authenticates the sender" but never explained that the receiver actually verifies it — I rewrote that section around the trusted-key and master-anchor model and stated the real limit plainly: it stops an outsider, not one trusted peer impersonating another. QUERY, CASCADE, and RENDEZVOUS were undocumented as message types entirely; I added minimal coverage of each, including the response-routing permission gate and its residual limitation, and the mailbox-node field now returned on RENDEZVOUS answers.

The permissions page got the escalate and propagate permissions added, plus a note that the HTTP and WebSocket transports enforce access control the same way. The network plugins page now says the HTTP plugin applies per-client restrictions, since it does. The handshake page now documents malformed-frame handling as current behavior.

`mkdocs build --strict` passes; the one nav warning about TODO.md is pre-existing and unrelated. I checked every behavior against source in the bus client, core, and HTTP protocol checkouts before writing anything. Three things I couldn't confirm from the checkouts available to me: the exact wire field name for the RENDEZVOUS mailbox, since that implementation lives in a repo I didn't have checked out (described in prose instead of a wire table); whether QUERY, CASCADE, and RENDEZVOUS are strictly asymmetric between listener and client roles (I described them symmetrically); and the exact boot-sequence ordering of automatic key generation (only the outward guarantee — an unwritable config directory doesn't stop boot — is stated). Flagging these here so a maintainer can close them.
