### PR TITLE
docs: beginner-proof guides for all four chat bridges

### DIFF
--- a/docs/09_matrix.md
+++ b/docs/09_matrix.md
@@ -1,38 +1,83 @@
 # HiveMind - Matrix Bridge
 
-[Matrix](https://matrix.org/) is a chat protocol. It works a little like email, but instantaneous and secure:
+[Matrix](https://matrix.org/) is an open chat network, a bit like email but instant. You register an account with any provider ("homeserver"), and from that account you can join rooms and talk to people on other homeservers, the same way you can email someone on a different mail provider. You can also run your own homeserver instead of using a public one.
 
-- You register an account with a provider.
-- Whatever your provider is, you can talk to people using other providers.
-- Just as you can use Outlook or Thunderbird with the same email account, you can use different Matrix apps with the same Matrix account.
+The Matrix bridge connects one Matrix room to a HiveMind hub. It acts as a HiveMind satellite: instead of a microphone, its input is anything said in the room that mentions the bot, and instead of a speaker, its output is the hub's reply posted back into the room. This turns a HiveMind hub, and the OVOS skills behind it, into a chatbot anyone in that room can talk to.
 
-![img_16.png](img_16.png)
+```
+Matrix room  ⇄  HiveMind-matrix-bridge  ⇄  HiveMind hub  ⇄  OVOS skills
+```
+
+## Get a bot account and an access token
+
+The bridge needs a Matrix account it can log in as, and the access token for that account. Two ways to get one:
+
+**Use a public homeserver.** Register an account for the bot on `matrix.org` (or any other public homeserver), log in once with a client such as [Element](https://element.io), then copy the account's access token: *Settings → Help & About → Access Token*.
+
+**Self-host.** Run a homeserver such as [Conduit](https://conduit.rs/) yourself, register the bot account on it, and get its token the same way. Self-hosting means the bot account is not tied to a third-party server, and you can keep the room off the public federation entirely.
+
+Either way, create or pick a room, note its alias (for example `#hivemind-bots:matrix.org`), and invite the bot account into that room.
 
 ## Install
 
-Install from [GitHub](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge).
+```bash
+pip install git+https://github.com/JarbasHiveMind/HiveMind-matrix-bridge
+```
 
-## Usage
+This installs the `HiveMind-matrix` command.
 
-![imagem](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge/assets/33701864/f70c7889-43eb-41b1-b295-d4d5040ab610)
+## Register the bridge on the hub
+
+On the machine running `hivemind-core`:
+
+```bash
+hivemind-core add-client --name matrix-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+A freshly registered client is denied every message type until you whitelist it. This step is easy to miss, and skipping it is the most common reason a bridge connects but never replies:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance matrix-bridge
+hivemind-core allow-msg speak matrix-bridge
+```
+
+The first command lets the bridge send what it hears into the hub. The second lets the hub's spoken replies come back out. Without both, the bridge sits there connected and silent.
+
+If you run more than one HiveMind bridge on the same machine (Matrix next to Mattermost, DeltaChat, or HackChat), give each one its own identity with `hivemind-client set-identity`. Bridges that share an identity share a Noise session pin, and the hub will treat reconnects from either one as the same client, which breaks encryption for both.
+
+## Run it
+
+```bash
+HiveMind-matrix run \
+  --botname thehivebot \
+  --matrixtoken "syt_your_access_token" \
+  --matrixhost "https://matrix.org" \
+  --room "#hivemind-bots:matrix.org"
+```
+
+The bridge logs a line for the Matrix connection and a line for the HiveMind connection when both come up.
+
+## Try it
+
+In the joined room, mention the bot:
 
 ```
-Usage: HiveMind-matrix run [OPTIONS]
-
-  connect a matrix chatroom to hivemind
-
-Options:
-  --botname TEXT      thehivebot
-  --matrixtoken TEXT  syt_dGhl.....
-  --matrixhost TEXT   https://matrix.org
-  --room TEXT         #hivemind-bots:matrix.org
-  --key TEXT          HiveMind access key (default read from identity file)
-  --password TEXT     HiveMind password (default read from identity file)
-  --host TEXT         HiveMind host (default read from identity file)
-  --port INTEGER      HiveMind port number (default: 5678)
-  --help              Show this message and exit.
-
+thehivebot what time is it?
 ```
+
+The bridge strips the mention, sends the rest to the hub as a `recognizer_loop:utterance`, waits for the hub's `speak` reply, and posts it back into the room.
+
+## Troubleshooting
+
+- **Bridge connects but the room never gets a reply**: the client is registered but not whitelisted. Run the two `allow-msg` commands above.
+- **`invalid api key` at connect time**: the bridge, or its `hivemind-bus-client` dependency, is older than the hub. Upgrade it.
+- **`reconnect worker already running` in the log**: a known issue in older `hivemind-bus-client` releases when a dropped connection's retries overlap. It is fixed upstream; upgrade.
+- **Handshake fails after the hub was reinstalled or the client's key changed**: the bridge is holding a stale Noise session pin. Clear it on the hub with `hivemind-core reset-noise-pin matrix-bridge` and restart the bridge.
+
+## More
+
+The bridge's own repository has a full [setup walkthrough](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge/blob/dev/docs/setup.md) and [operator setup guide](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge/blob/dev/docs/operator-setup.md), including how to self-host Conduit.
 
 ---
-[← OVOS Pipeline](pipeline.md) · [Home](index.md) · [DeltaChat →](10_deltachat.md)
+[← OpenVoiceOS Pipeline](pipeline.md) · [Home](index.md) · [Mattermost →](11_mattermost.md)

--- a/docs/10_deltachat.md
+++ b/docs/10_deltachat.md
@@ -1,10 +1,20 @@
 # DeltaChat Bridge
 
-[Delta Chat](https://delta.chat/en/) is a messaging app that works over e-mail.
+[Delta Chat](https://delta.chat/en/) is a messaging app that runs over ordinary email. Any two Delta Chat users can message each other using nothing but an email address, and the app hides the email plumbing behind a normal chat interface. It encrypts messages end-to-end with [Autocrypt](https://autocrypt.org/) once both sides have exchanged keys.
 
-It uses end-to-end encryption with the [Autocrypt](https://autocrypt.org/) and [CounterMITM](https://countermitm.readthedocs.io/en/latest/new.html) protocols, and has passed multiple security audits.
+The DeltaChat bridge gives a HiveMind hub its own Delta Chat identity. It logs in as a mailbox, and any message sent to that address becomes an utterance on the hub. The hub's spoken reply is sent back as a Delta Chat message in the same conversation.
 
-![img_12.png](img_12.png)
+```
+Delta Chat  ⇄  HiveMind-deltachat-bridge  ⇄  HiveMind hub  ⇄  OVOS skills
+```
+
+## Get the bot a mailbox
+
+The bridge needs an email account it can log in to with IMAP/SMTP. The easiest way is **chatmail**, a kind of account made specifically for Delta Chat that self-provisions with no signup form: open the Delta Chat app, choose "create a new account", and it registers one automatically on a public chatmail server (for example `nine.testrun.org`). Read the account's address and password back out of the app's settings, or provision one programmatically — see the [chatmail documentation](https://chatmail.at) for both.
+
+You can also use any regular IMAP/SMTP mailbox, or self-host a chatmail relay with [`chatmaild`](https://github.com/chatmail/relay) for full control.
+
+One thing this deployment hit in practice: the **first** message from a brand-new contact may go unanswered. Delta Chat treats an unknown sender as unverified until it completes an Autocrypt key exchange, so add the bot as a contact (or scan its invite QR code) and give it a moment before expecting a reply.
 
 ## Install
 
@@ -12,27 +22,57 @@ It uses end-to-end encryption with the [Autocrypt](https://autocrypt.org/) and [
 pip install HiveMind-deltachat-bridge
 ```
 
-## Usage
+This installs the `hm-deltachat-bridge` command.
 
-![img.png](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge/raw/master/img.png)
+## Register the bridge on the hub
+
+On the machine running `hivemind-core`:
 
 ```bash
-hm-deltachat-bridge --help
-usage: __main__.py [-h] --access_key ACCESS_KEY --email EMAIL --password
-                   PASSWORD [--crypto_key CRYPTO_KEY] [--name NAME]
-                   [--host HOST] [--port PORT]
-optional arguments:
-  -h, --help            show this help message and exit
-  --access_key ACCESS_KEY
-                        hivemind access key
-  --email EMAIL         deltachat email
-  --password PASSWORD   deltachat password
-  --crypto_key CRYPTO_KEY
-                        payload encryption key
-  --name NAME           human readable device name
-  --host HOST           HiveMind host
-  --port PORT           HiveMind port number
+hivemind-core add-client --name deltachat-bridge \
+  --access-key "your-access-key" --password "your-password"
 ```
 
+A freshly registered client is denied every message type until you whitelist it. Skipping this is the most common reason a bridge connects but never replies:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance deltachat-bridge
+hivemind-core allow-msg speak deltachat-bridge
+```
+
+If you run more than one HiveMind bridge on the same machine, give each its own identity with `hivemind-client set-identity`. Bridges that share an identity share a Noise session pin, and the hub treats reconnects from either as the same client, breaking encryption for both.
+
+## Run it
+
+```bash
+hm-deltachat-bridge \
+  --email "bot@example.com" \
+  --email-password "mailbox-password"
+```
+
+HiveMind credentials (`--key/--password/--host`) are read from the identity stored by `hivemind-client set-identity`, or can be passed as flags.
+
+## Try it
+
+From any Delta Chat app (or plain email), message the bot's address:
+
+```
+what time is it?
+```
+
+The bridge forwards the message to the hub, waits for the `speak` reply, and answers in the same chat.
+
+## Troubleshooting
+
+- **Bridge connects but never replies**: the client is registered but not whitelisted. Run the two `allow-msg` commands above.
+- **First message from a new contact gets no reply**: the contact needs to complete the Autocrypt key exchange first. Add the bot as a contact and wait a moment.
+- **Mailbox login fails**: verify IMAP/SMTP is enabled for the account, and that the password is an app password where the provider requires one.
+- **`invalid api key` at connect time**: the bridge, or its `hivemind-bus-client` dependency, is older than the hub. Upgrade it.
+- **Handshake fails after the hub was reinstalled or the client's key changed**: the bridge is holding a stale Noise session pin. Clear it on the hub with `hivemind-core reset-noise-pin deltachat-bridge` and restart the bridge.
+
+## More
+
+The bridge's own repository has a full [setup walkthrough](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge/blob/dev/docs/setup.md) and an [accounts & chatmail guide](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge/blob/dev/docs/accounts-and-chatmail.md) covering every way to get a mailbox.
+
 ---
-[← Matrix](09_matrix.md) · [Home](index.md) · [Home Assistant →](07_homeassistant.md)
+[← Mattermost](11_mattermost.md) · [Home](index.md) · [HackChat →](12_hackchat.md)

--- a/docs/11_mattermost.md
+++ b/docs/11_mattermost.md
@@ -1,0 +1,85 @@
+# HiveMind - Mattermost Bridge
+
+[Mattermost](https://mattermost.com/) is a self-hosted team chat app, similar to Slack: channels, direct messages, and bot accounts that post and read messages through an API.
+
+The Mattermost bridge connects a HiveMind hub to a Mattermost channel through a bot account. It watches the channels the bot is a member of, forwards any message that mentions the bot to the hub as an utterance, and posts the hub's spoken reply back into the channel.
+
+```
+Mattermost channel  ⇄  HiveMind_mattermost_bridge  ⇄  HiveMind hub  ⇄  OVOS skills
+```
+
+## Get a server and a bot account
+
+You need a Mattermost server (an existing team's server, or your own) and a bot account on it.
+
+**Use an existing server.** Ask a Mattermost System Console admin to create a bot account, or create a regular user account for the bridge to log in as. Note its login email and password, and add it to the channels it should answer in.
+
+**Self-host.** Run `mattermost-preview` (a single Docker container with the server and database bundled) if you just want to try the bridge without touching a production team's server. Create the team, channel, and bot account inside it the same way.
+
+## Install
+
+```bash
+pip install .
+```
+
+from a checkout of the repository, or install from PyPI once published. This provides the `hivemind-mattermost-bridge` command.
+
+## Register the bridge on the hub
+
+On the machine running `hivemind-core`:
+
+```bash
+hivemind-core add-client --name mattermost-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+A freshly registered client is denied every message type until you whitelist it. Skipping this is the most common reason a bridge connects but never replies:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance mattermost-bridge
+hivemind-core allow-msg speak mattermost-bridge
+```
+
+If you run more than one HiveMind bridge on the same machine, give each its own identity. Bridges that share an identity share a Noise session pin, and the hub treats reconnects from either as the same client, breaking encryption for both.
+
+## Run it
+
+```bash
+hivemind-mattermost-bridge \
+  --mail bot@example.com \
+  --pswd bot-password \
+  --url chat.example.com \
+  --tag @bot \
+  --host ws://127.0.0.1 \
+  --port 5678 \
+  --key your-access-key \
+  --password your-hivemind-password
+```
+
+`--url` is the bare Mattermost host, no `https://` prefix.
+
+## Try it
+
+In a channel the bot is a member of, mention it:
+
+```
+@bot what time is it?
+```
+
+The bridge forwards the message to the hub and posts the hub's reply back into the channel.
+
+## Troubleshooting
+
+- **Bridge connects but never replies**: the client is registered but not whitelisted. Run the two `allow-msg` commands above.
+- **Bot never answers**: confirm the bot account is a member of the channel and the message contains the trigger tag (`@bot` by default).
+- **Mattermost login fails**: check `--url` is the bare host with no scheme, and the bot's login and password are correct.
+- **`invalid api key` at connect time**: the bridge, or its `hivemind-bus-client` dependency, is older than the hub. Upgrade it.
+- **`reconnect worker already running` in the log**: a known issue in older `hivemind-bus-client` releases when a dropped connection's retries overlap. Fixed upstream; upgrade.
+- **Handshake fails after the hub was reinstalled or the client's key changed**: the bridge is holding a stale Noise session pin. Clear it on the hub with `hivemind-core reset-noise-pin mattermost-bridge` and restart the bridge.
+
+## More
+
+The bridge's own repository has a full [setup walkthrough](https://github.com/JarbasHiveMind/HiveMind_mattermost_bridge/blob/dev/docs/setup.md) and [operator setup guide](https://github.com/JarbasHiveMind/HiveMind_mattermost_bridge/blob/dev/docs/operator-setup.md).
+
+---
+[← Matrix](09_matrix.md) · [Home](index.md) · [DeltaChat →](10_deltachat.md)

--- a/docs/12_hackchat.md
+++ b/docs/12_hackchat.md
@@ -1,0 +1,77 @@
+# HiveMind - HackChat Bridge
+
+[hack.chat](https://hack.chat/) is a small, anonymous, no-signup chat site. You open a URL with a channel name in it (`https://hack.chat/?your_channel`) and you are in that channel, with a random nickname you can change. There is no account, no password, and no registration for anyone, human or bot.
+
+The HackChat bridge connects one hack.chat channel to a HiveMind hub. It joins the channel like any other participant, forwards every message it sees (except its own) to the hub as an utterance, and posts the hub's reply back as `@user , <answer>`.
+
+```
+hack.chat channel  ⇄  HiveMind-HackChatBridge  ⇄  HiveMind hub  ⇄  OVOS skills
+```
+
+## Get an account
+
+There is nothing to get. Pick a channel name — something obscure, since anyone who knows it can join — and a nickname for the bot. That's the whole "account" step.
+
+## Install
+
+```bash
+pip install .
+```
+
+from a checkout of the repository, or from PyPI once published. This provides the `hivemind-hackchat-bridge` command.
+
+## Register the bridge on the hub
+
+On the machine running `hivemind-core`:
+
+```bash
+hivemind-core add-client --name hackchat-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+A freshly registered client is denied every message type until you whitelist it. Skipping this is the most common reason a bridge connects but never replies:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance hackchat-bridge
+hivemind-core allow-msg speak hackchat-bridge
+```
+
+If you run more than one HiveMind bridge on the same machine, give each its own credentials. Bridges that share an identity share a Noise session pin, and the hub treats reconnects from either as the same client, breaking encryption for both.
+
+## Run it
+
+```bash
+hivemind-hackchat-bridge \
+  --channel your_channel \
+  --username Jarbas_BOT \
+  --access-key "your-access-key" \
+  --password "your-password" \
+  --host ws://127.0.0.1 \
+  --port 5678
+```
+
+## Try it
+
+Open `https://hack.chat/?your_channel` in a browser and type:
+
+```
+what time is it?
+```
+
+The bridge forwards the message to the hub and posts the reply back as `@you , <answer>`.
+
+## Troubleshooting
+
+- **Bridge connects but never replies**: the client is registered but not whitelisted. Run the two `allow-msg` commands above.
+- **Bot joins but never answers**: confirm the hub is reachable and the access key is registered (`hivemind-core list-clients`), and that the hub produces a `speak` for the answer.
+- **Wrong channel**: the bot and the user must be in the same hack.chat channel name — open the same `https://hack.chat/?<channel>` URL.
+- **`invalid api key` at connect time**: the bridge, or its `hivemind-bus-client` dependency, is older than the hub. Upgrade it.
+- **`reconnect worker already running` in the log**: a known issue in older `hivemind-bus-client` releases when a dropped connection's retries overlap. Fixed upstream; upgrade.
+- **Handshake fails after the hub was reinstalled or the client's key changed**: the bridge is holding a stale Noise session pin. Clear it on the hub with `hivemind-core reset-noise-pin hackchat-bridge` and restart the bridge.
+
+## More
+
+The bridge's own repository has a full [setup walkthrough](https://github.com/JarbasHiveMind/HiveMind-HackChatBridge/blob/dev/docs/setup.md) and [operator setup guide](https://github.com/JarbasHiveMind/HiveMind-HackChatBridge/blob/dev/docs/operator-setup.md).
+
+---
+[← DeltaChat](10_deltachat.md) · [Home](index.md) · [Home Assistant →](07_homeassistant.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,9 @@ nav:
       - Persona / LLM hub: 08_persona.md
       - Bridges overview: gpt_bridges.md
       - Matrix: 09_matrix.md
+      - Mattermost: 11_mattermost.md
       - DeltaChat: 10_deltachat.md
+      - HackChat: 12_hackchat.md
       - Home Assistant: 07_homeassistant.md
     - Topologies:
       - Nested Hives: 15_nested.md


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Rewrites the Matrix and DeltaChat integration pages (the DeltaChat page described a `hm-deltachat-bridge` CLI with `--access_key`/`--crypto_key` flags that no longer exist in the current bridge) and adds new Mattermost and HackChat pages. All four now follow the same beginner path: what the bridged service is in plain terms, how to get an account or credentials from scratch, install, register the bridge on the hub, and — the step every existing doc across the ecosystem was missing — the `hivemind-core allow-msg recognizer_loop:utterance <name>` / `allow-msg speak <name>` whitelist a fresh client needs before the hub will act on anything it sends.

Troubleshooting entries (stale Noise pin via `reset-noise-pin`, `invalid api key` from an outdated client, the upstream-fixed reconnect-worker issue) are grounded in a live 4-bridge deployment where all four bridges are connected to one hub right now.

Wires the two new pages (`11_mattermost.md`, `12_hackchat.md`) into `mkdocs.yml` nav. `mkdocs build --strict` passes clean (only an unrelated pre-existing INFO note about `TODO.md` not being in the nav, not a warning or error).

No screenshots included in this PR — see the note in the companion bridge-repo PRs for why.