### PR TITLE
docs: SIP/baresip and Telegram bridge pages, refresh media-player/twitch

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -23,6 +23,8 @@ it holds an access key and relays messages to `hivemind-core`.
 | [DeltaChat](deltachat.md) | Email-based encrypted messaging | Email account |
 | [Mattermost](mattermost.md) | A Mattermost team channel | Mattermost bot login |
 | [Twitch](twitch.md) | Twitch stream chat | Twitch chat OAuth token |
+| [Telegram](telegram.md) | A Telegram bot chat | Telegram bot token (@BotFather) |
+| [SIP / baresip](sip.md) | Ordinary phone calls | A SIP account (self-hosted or a provider) |
 | [HackChat](hackchat.md) | An anonymous hack.chat channel | HiveMind only |
 
 !!! tip "Start with the simplest"

--- a/docs/integrations/media-player.md
+++ b/docs/integrations/media-player.md
@@ -82,7 +82,16 @@ hivemind-core allow-msg "ovos.common_play.previous" <id>
 ```
 
 The repository's permissions reference lists the full OCP, audio, and (optional) PHAL
-volume message sets.
+volume message sets. A freshly added client is denied every message type until you
+grant it — this is the step people skip, and the failure is silent: commands are
+accepted by the hub but nothing plays.
+
+!!! warning "Headless devices need a null audio sink"
+    If the device has no physical speakers — a server, a container — point the OCP
+    backends (mpv, vlc) at a null sink instead of real hardware, for example
+    `mpv --ao=null` or `vlc --aout=dummy`. Without a working sink, real or null,
+    playback commands are accepted but nothing plays, and mpv/vlc can error out
+    trying to open a device that doesn't exist.
 
 ---
 

--- a/docs/integrations/sip.md
+++ b/docs/integrations/sip.md
@@ -1,0 +1,108 @@
+# SIP / baresip Bridge
+
+Turn your hive into something you can call on the phone. The
+[HiveMind-baresip-bridge](https://github.com/JarbasHiveMind/HiveMind-baresip-bridge)
+answers ordinary SIP calls with [baresip](https://github.com/baresip/baresip), a SIP
+softphone, and turns the call into a voice conversation with your hive. There's no
+wakeword — an answered call is the activation signal — and the caller's replies are
+spoken back into the call.
+
+!!! abstract "In a nutshell"
+    - Runs the `hivemind-baresip-bridge` console command, wrapping a local `baresip` process.
+    - No wakeword: an answered call *is* the activation. Local VAD segments the caller's speech.
+    - The bridge asks `hivemind-core` to synthesize replies (`speak:b64_audio`) and plays the audio into the call — it does not synthesize speech itself.
+
+!!! tip "Beginner's mental model"
+    A phone call to your hive works like a voice satellite, except the microphone is a
+    phone call instead of a room. Whoever calls in gets to talk to your assistant.
+
+---
+
+## Getting a SIP account
+
+You need something that can route a call to baresip:
+
+- **Self-host [Asterisk](https://www.asterisk.org/)**, a SIP server, and register two
+  extensions on it — one for the bridge, one for whatever device calls in. Asterisk
+  only needs to be reachable by baresip and the calling device, so a LAN or a Tailscale
+  network is enough; it doesn't need to be public. The extension number and password
+  become the bridge's `sip_user` / `sip_password`, and the Asterisk host becomes
+  `sip_gateway`.
+- **Use a SIP trunk provider.** Any VoIP reseller selling SIP trunking gives you a
+  username, password, and gateway hostname — the same three values, at the cost of a
+  subscription, but with a real phone number the public can dial.
+
+---
+
+## Install
+
+!!! warning "Not on PyPI yet"
+    `pip install HiveMind-baresip-bridge` fails
+    ([issue #5](https://github.com/JarbasHiveMind/HiveMind-baresip-bridge/issues/5)).
+    Install from source, or build the repo's Dockerfile, which also installs a working
+    `baresip` binary.
+
+```bash
+git clone https://github.com/JarbasHiveMind/HiveMind-baresip-bridge
+cd HiveMind-baresip-bridge
+pip install .
+```
+
+A working `baresip` binary must be on `PATH` (`apt install baresip` on
+Debian/Ubuntu), or use `docker build -t hivemind-baresip-bridge .` instead.
+
+---
+
+## Configuration
+
+SIP settings live in a JSON file, `~/.hivemind_baresip_bridge.json` by default:
+
+```json
+{
+  "sip_user": "1000",
+  "sip_password": "secret",
+  "sip_gateway": "sip.example.com",
+  "sip_transport": "udp",
+  "auto_answer": true,
+  "allowlist": []
+}
+```
+
+`allowlist` restricts which caller numbers get answered; leave it empty to accept any
+caller. HiveMind hub credentials (access key, password, host) are set separately, the
+same way as any other HiveMind client.
+
+---
+
+## Permissions
+
+```bash
+hivemind-core add-client --name baresip-bridge
+hivemind-core allow-msg "recognizer_loop:utterance" <id>
+hivemind-core allow-msg "speak:b64_audio" <id>
+hivemind-core allow-msg "baresip.dtmf" <id>
+```
+
+Skipping `speak:b64_audio` is the classic failure mode: calls connect and get
+transcribed fine, but the bridge never speaks back, because the hub silently drops the
+reply-audio message instead of erroring.
+
+---
+
+## Run
+
+```bash
+hivemind-baresip-bridge --host ws://core.example.com --key <access-key> --password <password>
+```
+
+Call the SIP extension you configured. You should hear the assistant's reply spoken
+back into the call.
+
+---
+
+## Source
+
+Validated against the HiveMind source:
+
+- [`README.md`](https://github.com/JarbasHiveMind/HiveMind-baresip-bridge/blob/HEAD/README.md) — architecture, install, configuration
+- [`docs/setup.md`](https://github.com/JarbasHiveMind/HiveMind-baresip-bridge/blob/HEAD/docs/setup.md) — full Asterisk walkthrough and troubleshooting

--- a/docs/integrations/telegram.md
+++ b/docs/integrations/telegram.md
@@ -1,0 +1,88 @@
+# Telegram Bridge
+
+Give your hive a Telegram bot. The
+[hivemind-telegram-bridge](https://github.com/JarbasHiveMind/hivemind-telegram-bridge)
+turns any text message sent to the bot into a HiveMind utterance, and posts the hive's
+spoken reply back as a text message in the same chat.
+
+!!! abstract "In a nutshell"
+    - Runs the `hivemind-telegram-bridge` console command, using `python-telegram-bot`'s async, long-polling `Application`.
+    - Forwards each text message as `recognizer_loop:utterance`; posts `speak` replies back into the originating chat.
+    - Waits for the HiveMind handshake to complete before forwarding anything, so an early message can't get the connection killed.
+
+!!! tip "Beginner's mental model"
+    Message the bot like you'd message a friend. Whatever you type is forwarded to your
+    hive, and the hive's answer comes back as the bot's reply.
+
+---
+
+## Get a bot token
+
+1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather).
+2. Send `/newbot` and follow the prompts: pick a display name, then a username ending
+   in `bot` (it must be unique across Telegram).
+3. BotFather replies with a token, e.g.
+   `123456789:AAExampleTokenDoNotShareThisInAnyForm`.
+
+!!! warning "Treat the token like a password"
+    Anyone who has it can send messages as your bot and read what's sent to it. Don't
+    commit it to a repo, paste it into a public issue, or pass it on a shared shell's
+    command line — use an environment variable instead.
+
+---
+
+## Install
+
+```bash
+git clone https://github.com/JarbasHiveMind/hivemind-telegram-bridge
+cd hivemind-telegram-bridge
+pip install .
+```
+
+Or with Docker — see the repository README for the full `docker run` /
+`docker-compose.yml` invocation.
+
+---
+
+## Permissions
+
+```bash
+hivemind-core add-client --name telegram-bridge
+hivemind-core allow-msg "recognizer_loop:utterance" <id>
+hivemind-core allow-msg "speak" <id>
+```
+
+A freshly added client is denied every message type by default. Skipping this step is
+the classic silent failure: the bot receives your message fine, but nothing ever comes
+back, because the hub drops the forwarded utterance instead of erroring.
+
+---
+
+## Run
+
+```bash
+hivemind-telegram-bridge \
+  --token <your-botfather-token> \
+  --access-key <key> --password <password> \
+  --host ws://core.example.com --port 5678 \
+  --site-id telegram-bridge
+```
+
+Give it its own `--site-id` if you run other HiveMind clients on the same host, so it
+doesn't collide over the same identity file and pinned peer keys.
+
+By default the bridge answers in any chat it's part of. Restrict it to specific chats
+with repeated `--allowed-chat <chat_id>` flags.
+
+Message your bot to try it. You should see the bridge log the incoming message, the
+hub log the utterance and its `speak` reply, and the bot post that reply back into the
+chat.
+
+---
+
+## Source
+
+Validated against the HiveMind source:
+
+- [`readme.md`](https://github.com/JarbasHiveMind/hivemind-telegram-bridge/blob/HEAD/readme.md) — architecture, install, Docker, and message flow
+- [`docs/setup.md`](https://github.com/JarbasHiveMind/hivemind-telegram-bridge/blob/HEAD/docs/setup.md) — full BotFather walkthrough and troubleshooting

--- a/docs/integrations/twitch.md
+++ b/docs/integrations/twitch.md
@@ -21,8 +21,12 @@ satellite relaying [utterances](../reference/glossary.md#utterance) to hivemind-
 
 ## Install
 
+This package is not on PyPI. Install from a checkout:
+
 ```bash
-pip install HiveMind-twitch-bridge
+git clone https://github.com/JarbasHiveMind/HiveMind-twitch-bridge
+cd HiveMind-twitch-bridge
+pip install .
 ```
 
 This installs the `hivemind-twitch-bridge` console command.
@@ -104,11 +108,22 @@ to `hivemind-core`; the `speak` response is sent back to the channel as
 
 ## Permissions
 
-The bridge client needs at minimum:
+Register the bridge as a HiveMind client first:
 
 ```bash
+hivemind-core add-client --name twitch-bridge
+```
+
+This prints an access key, password, and a client/Node ID. A freshly added client is
+denied every message type by default — grant what the bridge needs before running it:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:utterance" <id>
 hivemind-core allow-msg "speak" <id>
 ```
+
+Skipping this is the most common reason the bridge joins chat fine but never posts a
+reply.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,8 @@ nav:
     - DeltaChat: integrations/deltachat.md
     - Mattermost: integrations/mattermost.md
     - Twitch: integrations/twitch.md
+    - Telegram: integrations/telegram.md
+    - SIP / baresip: integrations/sip.md
     - HackChat: integrations/hackchat.md
 
   - Developer Guide:


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds docs/integrations/sip.md (new, baresip bridge — SIP account from scratch, not-on-PyPI warning, allow-msg) and docs/integrations/telegram.md (new, BotFather flow, allow-msg). Refreshes docs/integrations/media-player.md (adds the headless/null-sink warning) and docs/integrations/twitch.md (the install section wrongly said `pip install HiveMind-twitch-bridge` — that package is not on PyPI either, verified with a 404 against pypi.org's JSON API — fixed to source install, and added the missing add-client + allow-msg step). Updates mkdocs.yml nav and docs/integrations/index.md's table.

`mkdocs build --strict` passes in a throwaway venv (mkdocs + mkdocs-material per requirements.txt).

This is on its own branch off master to avoid clobbering the other docs-sync work in flight on docs/protocol-behaviour-sync. If mkdocs.yml conflicts on merge, both nav additions need to survive the rebase.

Sourced from each bridge repo's README/docs (cross-referenced against their own PRs from this session) and a live PyPI check. Not independently re-tested against a live SIP call, Telegram bot, or Twitch bot in this session.